### PR TITLE
Automatically show pictures if a CW blackout box is clicked.

### DIFF
--- a/Mastonaut/View Controllers/Media Attachments/AttachmentViewController.swift
+++ b/Mastonaut/View Controllers/Media Attachments/AttachmentViewController.swift
@@ -127,6 +127,10 @@ class AttachmentViewController: NSViewController
 		}
 	}
 
+	@objc func toggleMediaVisibility() {
+		setMediaHidden(!isMediaHidden)
+	}
+	
 	func setMediaHidden(_ hideMedia: Bool, animated: Bool = true)
 	{
 		let imageViews = [firstImageView, secondImageView, thirdImageView, fourthImageView].compacted()
@@ -138,6 +142,9 @@ class AttachmentViewController: NSViewController
 	private func setupCoverView()
 	{
 		view.addSubview(coverView)
+		coverView.target = self
+		coverView.action = #selector(toggleMediaVisibility)
+		// FIXME: Fast double-clicks can cause the view to re-hide.
 
 		NSLayoutConstraint.activate([
 			view.leftAnchor.constraint(equalTo: coverView.leftAnchor),

--- a/Mastonaut/Views/CoverView.swift
+++ b/Mastonaut/Views/CoverView.swift
@@ -23,6 +23,9 @@ import CoreTootin
 class CoverView: BorderView
 {
 	private var didInstallLabel: Bool = false
+	
+	var target: Any? = nil
+	var action: Selector? = nil
 
 	init(backgroundColor: NSColor, textColor: NSColor = .labelColor, message: String)
 	{
@@ -76,5 +79,11 @@ class CoverView: BorderView
 			bottomAnchor.constraint(greaterThanOrEqualTo: label.bottomAnchor),
 			label.topAnchor.constraint(greaterThanOrEqualTo: topAnchor)
 		])
+	}
+	
+	override func mouseDown(with event: NSEvent) {
+		if let target = self.target as? NSObjectProtocol, let action = self.action {
+			target.perform(action, with: self)
+		}
 	}
 }

--- a/Mastonaut/Views/Table Cell Views/StatusTableCellView.swift
+++ b/Mastonaut/Views/Table Cell Views/StatusTableCellView.swift
@@ -77,8 +77,11 @@ class StatusTableCellView: MastonautTableCellView, StatusDisplaying, StatusInter
 
 	private lazy var spoilerCoverView: NSView =
 		{
-			return CoverView(backgroundColor: NSColor(named: "SpoilerCoverBackground")!,
+			let coverView = CoverView(backgroundColor: NSColor(named: "SpoilerCoverBackground")!,
 							 message: 🔠("Content Hidden: Click warning button below to toggle display."))
+			coverView.target = self
+			coverView.action = #selector(toggleContentVisibility)
+			return coverView
 		}()
 
 	private static let _authorLabelAttributes: [NSAttributedString.Key: AnyObject] = [
@@ -439,7 +442,8 @@ class StatusTableCellView: MastonautTableCellView, StatusDisplaying, StatusInter
 		case (warningButton, .on):
 			userDidInteractWithVisibilityControls = true
 			setContentHidden(false)
-			
+			setMediaHidden(false)
+
 		case (warningButton, .off):
 			userDidInteractWithVisibilityControls = true
 			setContentHidden(true)
@@ -457,10 +461,13 @@ class StatusTableCellView: MastonautTableCellView, StatusDisplaying, StatusInter
 		}
 	}
 	
-	func toggleContentVisibility() {
+	@objc func toggleContentVisibility() {
 		guard hasSpoiler else { return }
 		
 		setContentHidden(!isContentHidden)
+		if (isMediaHidden && !isContentHidden) {
+			setMediaHidden(isContentHidden)
+		}
 		
 		userDidInteractWithVisibilityControls = true
 	}


### PR DESCRIPTION
Allow clicking the "content warning" blocker to show text/images behind a CW.