### PR TITLE
Fix clipped popup button in the Composing prefs

### DIFF
--- a/Mastonaut/Storyboards/Preferences.storyboard
+++ b/Mastonaut/Storyboards/Preferences.storyboard
@@ -519,18 +519,18 @@
         <scene sceneID="qzT-XH-z0m">
             <objects>
                 <viewController title="Composing" showSeguePresentationStyle="single" id="sar-Nn-LHe" customClass="ComposingPreferencesController" customModule="Mastonaut" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" id="wIY-Oo-Tb0">
-                        <rect key="frame" x="0.0" y="0.0" width="670" height="264"/>
+                    <view key="view" misplaced="YES" id="wIY-Oo-Tb0">
+                        <rect key="frame" x="0.0" y="0.0" width="670" height="270"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="20" horizontalStackHuggingPriority="250.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalCompressionResistancePriority="250" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fRF-wq-Gmh">
-                                <rect key="frame" x="20" y="20" width="630" height="224"/>
+                                <rect key="frame" x="20" y="20" width="630" height="232"/>
                                 <subviews>
                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="V1f-eA-FlS">
-                                        <rect key="frame" x="0.0" y="204" width="630" height="20"/>
+                                        <rect key="frame" x="0.0" y="204" width="630" height="28"/>
                                         <subviews>
                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hRH-MX-k5T">
-                                                <rect key="frame" x="-2" y="3" width="244" height="16"/>
+                                                <rect key="frame" x="-2" y="7" width="244" height="16"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="240" id="M32-KN-sRR"/>
                                                 </constraints>
@@ -541,7 +541,7 @@
                                                 </textFieldCell>
                                             </textField>
                                             <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="MCh-KT-Z0x">
-                                                <rect key="frame" x="249" y="-4" width="78" height="25"/>
+                                                <rect key="frame" x="249" y="0.0" width="78" height="25"/>
                                                 <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="H33-Fg-GYd" id="63Y-s4-2M3">
                                                     <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                                     <font key="font" metaFont="menu"/>
@@ -559,8 +559,8 @@
                                             <constraint firstItem="hRH-MX-k5T" firstAttribute="leading" secondItem="V1f-eA-FlS" secondAttribute="leading" id="85z-d2-D1d"/>
                                             <constraint firstItem="hRH-MX-k5T" firstAttribute="firstBaseline" secondItem="MCh-KT-Z0x" secondAttribute="firstBaseline" id="i2u-Rp-rOY"/>
                                             <constraint firstItem="MCh-KT-Z0x" firstAttribute="leading" secondItem="hRH-MX-k5T" secondAttribute="trailing" constant="12" id="kdI-xi-ExQ"/>
-                                            <constraint firstItem="MCh-KT-Z0x" firstAttribute="top" secondItem="V1f-eA-FlS" secondAttribute="top" id="rvg-pl-iYe"/>
-                                            <constraint firstAttribute="bottom" secondItem="MCh-KT-Z0x" secondAttribute="bottom" id="xu5-fK-wLA"/>
+                                            <constraint firstItem="MCh-KT-Z0x" firstAttribute="top" secondItem="V1f-eA-FlS" secondAttribute="top" constant="4" id="rvg-pl-iYe"/>
+                                            <constraint firstAttribute="bottom" secondItem="MCh-KT-Z0x" secondAttribute="bottom" constant="4" id="xu5-fK-wLA"/>
                                         </constraints>
                                     </customView>
                                     <customView horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="JOb-HG-dyh">


### PR DESCRIPTION
The "default status privacy" popup bottom and top is clipped, this probably happened because the UI was made on macOS 10.15 or a previous version, and then macOS 11 changed UI style and added a shadow around the buttons, but didn't change the button intrinsic size.
Anyway this led to a lot of clipped UI elements in macOS, even in Apple softwares, but this is another story.