### PR TITLE
#83: custom timeline/conversation font family + size

### DIFF
--- a/CoreTootin/Agents/MastonautPreferences.swift
+++ b/CoreTootin/Agents/MastonautPreferences.swift
@@ -94,41 +94,41 @@ public class MastonautPreferences: PreferencesController
 		defaults.setValue(newValue.familyName, forKey: familyKey)
 		defaults.setValue(newValue.pointSize, forKey: sizeKey)
 	}
-	
+
 	// FIXME: I can probably use key paths here?
 
 	public static let defaultTimelineFont = NSFont.systemFont(ofSize: 13)
 	public static let defaultFocusedFont = NSFont.systemFont(ofSize: 16)
 
-	public let timelineFontFamilyKey = "timelineFontFamily"
-	public let timelineFontSizeKey = "timelineFontSize"
+	public static let timelineFontFamilyKey = "timelineFontFamily"
+	public static let timelineFontSizeKey = "timelineFontSize"
 
 	@objc public dynamic var timelineFont: NSFont
 	{
 		get
 		{
-			return getFont(familyKey: timelineFontFamilyKey, sizeKey: timelineFontSizeKey) ??
+			return getFont(familyKey: MastonautPreferences.timelineFontFamilyKey, sizeKey: MastonautPreferences.timelineFontSizeKey) ??
 				MastonautPreferences.defaultTimelineFont
 		}
 		set
 		{
-			setFont(newValue: newValue, familyKey: timelineFontFamilyKey, sizeKey: timelineFontSizeKey)
+			setFont(newValue: newValue, familyKey: MastonautPreferences.timelineFontFamilyKey, sizeKey: MastonautPreferences.timelineFontSizeKey)
 		}
 	}
-	
-	public let focusedFontFamilyKey = "focusedFontFamily"
-	public let focusedFontSizeKey = "focusedFontSize"
+
+	public static let focusedFontFamilyKey = "focusedFontFamily"
+	public static let focusedFontSizeKey = "focusedFontSize"
 
 	@objc public dynamic var focusedFont: NSFont
 	{
 		get
 		{
-			return getFont(familyKey: focusedFontFamilyKey, sizeKey: focusedFontSizeKey) ??
+			return getFont(familyKey: MastonautPreferences.focusedFontFamilyKey, sizeKey: MastonautPreferences.focusedFontSizeKey) ??
 				MastonautPreferences.defaultFocusedFont
 		}
 		set
 		{
-			setFont(newValue: newValue, familyKey: focusedFontFamilyKey, sizeKey: focusedFontSizeKey)
+			setFont(newValue: newValue, familyKey: MastonautPreferences.focusedFontFamilyKey, sizeKey: MastonautPreferences.focusedFontSizeKey)
 		}
 	}
 

--- a/CoreTootin/Agents/MastonautPreferences.swift
+++ b/CoreTootin/Agents/MastonautPreferences.swift
@@ -97,38 +97,38 @@ public class MastonautPreferences: PreferencesController
 
 	// FIXME: I can probably use key paths here?
 
-	public static let defaultTimelineFont = NSFont.systemFont(ofSize: 13)
-	public static let defaultFocusedFont = NSFont.systemFont(ofSize: 16)
+	public static let defaultStatusFont = NSFont.systemFont(ofSize: 13)
+	public static let defaultFocusedStatusFont = NSFont.systemFont(ofSize: 16)
 
-	public static let timelineFontFamilyKey = "timelineFontFamily"
-	public static let timelineFontSizeKey = "timelineFontSize"
+	public static let statusFontFamilyKey = "statusFontFamily"
+	public static let statusFontSizeKey = "statusFontSize"
 
-	@objc public dynamic var timelineFont: NSFont
+	@objc public dynamic var statusFont: NSFont
 	{
 		get
 		{
-			return getFont(familyKey: MastonautPreferences.timelineFontFamilyKey, sizeKey: MastonautPreferences.timelineFontSizeKey) ??
-				MastonautPreferences.defaultTimelineFont
+			return getFont(familyKey: MastonautPreferences.statusFontFamilyKey, sizeKey: MastonautPreferences.statusFontSizeKey) ??
+				MastonautPreferences.defaultStatusFont
 		}
 		set
 		{
-			setFont(newValue: newValue, familyKey: MastonautPreferences.timelineFontFamilyKey, sizeKey: MastonautPreferences.timelineFontSizeKey)
+			setFont(newValue: newValue, familyKey: MastonautPreferences.statusFontFamilyKey, sizeKey: MastonautPreferences.statusFontSizeKey)
 		}
 	}
 
-	public static let focusedFontFamilyKey = "focusedFontFamily"
-	public static let focusedFontSizeKey = "focusedFontSize"
+	public static let focusedStatusFontFamilyKey = "focusedStatusFontFamily"
+	public static let focusedStatusFontSizeKey = "focusedStatusFontSize"
 
-	@objc public dynamic var focusedFont: NSFont
+	@objc public dynamic var focusedStatusFont: NSFont
 	{
 		get
 		{
-			return getFont(familyKey: MastonautPreferences.focusedFontFamilyKey, sizeKey: MastonautPreferences.focusedFontSizeKey) ??
-				MastonautPreferences.defaultFocusedFont
+			return getFont(familyKey: MastonautPreferences.focusedStatusFontFamilyKey, sizeKey: MastonautPreferences.focusedStatusFontSizeKey) ??
+				MastonautPreferences.defaultFocusedStatusFont
 		}
 		set
 		{
-			setFont(newValue: newValue, familyKey: MastonautPreferences.focusedFontFamilyKey, sizeKey: MastonautPreferences.focusedFontSizeKey)
+			setFont(newValue: newValue, familyKey: MastonautPreferences.focusedStatusFontFamilyKey, sizeKey: MastonautPreferences.focusedStatusFontSizeKey)
 		}
 	}
 

--- a/CoreTootin/Agents/MastonautPreferences.swift
+++ b/CoreTootin/Agents/MastonautPreferences.swift
@@ -23,7 +23,7 @@ public let Preferences = MastonautPreferences.instance
 
 public class MastonautPreferences: PreferencesController
 {
-	private static var sharedInstance: MastonautPreferences! = nil
+	private static var sharedInstance: MastonautPreferences!
 
 	override var suiteName: String?
 	{
@@ -31,7 +31,7 @@ public class MastonautPreferences: PreferencesController
 	}
 
 	/// Initializer declared as private to avoid accidental creation of new instances.
-	private override init()
+	override private init()
 	{
 		super.init()
 
@@ -45,7 +45,7 @@ public class MastonautPreferences: PreferencesController
 		{
 			sharedInstance = MastonautPreferences()
 		}
-		
+
 		return sharedInstance
 	}
 
@@ -74,7 +74,7 @@ public class MastonautPreferences: PreferencesController
 		get { return bool(forKey: #keyPath(didMigrateToSharedLocalKeychain)) ?? false }
 		set { defaults.setValue(newValue, forKey: #keyPath(didMigrateToSharedLocalKeychain)) }
 	}
-	
+
 	@objc public dynamic var appearance: Appearance
 	{
 		get { return integerRepresentable(for: #keyPath(appearance), default: .auto) }
@@ -186,7 +186,8 @@ public class MastonautPreferences: PreferencesController
 
 	public func storedFrame(forTimelineWindowIndex index: Int) -> NSRect?
 	{
-		guard let frames: [String: String] = object(forKey: "MastonautPreferences.preservedWindowFrames") else
+		guard let frames: [String: String] = object(forKey: "MastonautPreferences.preservedWindowFrames")
+		else
 		{
 			return nil
 		}
@@ -200,22 +201,24 @@ public class MastonautPreferences: PreferencesController
 		frames["\(index)"] = NSStringFromRect(frame)
 		defaults.setValue(frames, forKey: "MastonautPreferences.preservedWindowFrames")
 	}
-	
+
 	// KVO
-	
-	public func addObserver(_ observer: NSObject, forKeyPath keyPath: String) {
+
+	public func addObserver(_ observer: NSObject, forKeyPath keyPath: String)
+	{
 		defaults.addObserver(observer, forKeyPath: keyPath, context: nil)
 	}
 }
 
 public extension MastonautPreferences
 {
-	@objc enum Appearance : Int {
-	    case auto = 1
-	    case light
-	    case dark
-    }
-	
+	@objc enum Appearance: Int
+	{
+		case auto = 1
+		case light
+		case dark
+	}
+
 	@objc enum MediaDisplayMode: Int
 	{
 		case alwaysHide = 1
@@ -248,9 +251,9 @@ public extension MastonautPreferences
 		{
 			switch self
 			{
-			case .public:	return 🔠("Public")
-			case .unlisted:	return 🔠("Unlisted")
-			case .private:	return 🔠("Private")
+			case .public: return 🔠("Public")
+			case .unlisted: return 🔠("Unlisted")
+			case .private: return 🔠("Private")
 			}
 		}
 
@@ -258,9 +261,9 @@ public extension MastonautPreferences
 		{
 			switch self
 			{
-			case .public:	return NSImage(named: "globe")
-			case .unlisted:	return NSImage(named: "padlock_open")
-			case .private:	return NSImage(named: "padlock")
+			case .public: return NSImage(named: "globe")
+			case .unlisted: return NSImage(named: "padlock_open")
+			case .private: return NSImage(named: "padlock")
 			}
 		}
 	}

--- a/CoreTootin/Agents/MastonautPreferences.swift
+++ b/CoreTootin/Agents/MastonautPreferences.swift
@@ -97,7 +97,7 @@ public class MastonautPreferences: PreferencesController
 
 	// FIXME: I can probably use key paths here?
 
-	public static let defaultStatusFont = NSFont.systemFont(ofSize: 13)
+	public static let defaultStatusFont = NSFont.systemFont(ofSize: 14)
 	public static let defaultFocusedStatusFont = NSFont.systemFont(ofSize: 16)
 
 	public static let statusFontFamilyKey = "statusFontFamily"

--- a/CoreTootin/Agents/MastonautPreferences.swift
+++ b/CoreTootin/Agents/MastonautPreferences.swift
@@ -83,6 +83,55 @@ public class MastonautPreferences: PreferencesController
 
 	// Viewing preferences
 
+	private func getFont(familyKey: String, sizeKey: String) -> NSFont?
+	{
+		NSFont(name: defaults.string(forKey: familyKey) ?? "",
+		       size: CGFloat(defaults.float(forKey: sizeKey)))
+	}
+
+	private func setFont(newValue: NSFont, familyKey: String, sizeKey: String)
+	{
+		defaults.setValue(newValue.familyName, forKey: familyKey)
+		defaults.setValue(newValue.pointSize, forKey: sizeKey)
+	}
+	
+	// FIXME: I can probably use key paths here?
+
+	public static let defaultTimelineFont = NSFont.systemFont(ofSize: 13)
+	public static let defaultFocusedFont = NSFont.systemFont(ofSize: 16)
+
+	public let timelineFontFamilyKey = "timelineFontFamily"
+	public let timelineFontSizeKey = "timelineFontSize"
+
+	@objc public dynamic var timelineFont: NSFont
+	{
+		get
+		{
+			return getFont(familyKey: timelineFontFamilyKey, sizeKey: timelineFontSizeKey) ??
+				MastonautPreferences.defaultTimelineFont
+		}
+		set
+		{
+			setFont(newValue: newValue, familyKey: timelineFontFamilyKey, sizeKey: timelineFontSizeKey)
+		}
+	}
+	
+	public let focusedFontFamilyKey = "focusedFontFamily"
+	public let focusedFontSizeKey = "focusedFontSize"
+
+	@objc public dynamic var focusedFont: NSFont
+	{
+		get
+		{
+			return getFont(familyKey: focusedFontFamilyKey, sizeKey: focusedFontSizeKey) ??
+				MastonautPreferences.defaultFocusedFont
+		}
+		set
+		{
+			setFont(newValue: newValue, familyKey: focusedFontFamilyKey, sizeKey: focusedFontSizeKey)
+		}
+	}
+
 	@objc public dynamic var mediaDisplayMode: MediaDisplayMode
 	{
 		get { return integerRepresentable(for: #keyPath(mediaDisplayMode), default: .hideSensitiveMedia) }

--- a/Mastonaut.xcodeproj/project.pbxproj
+++ b/Mastonaut.xcodeproj/project.pbxproj
@@ -523,6 +523,7 @@
 		5F4DAAAC29FDA15E009FA0AE /* FontPicker in Frameworks */ = {isa = PBXBuildFile; productRef = 5F4DAAAB29FDA15E009FA0AE /* FontPicker */; };
 		5F4DAAAE29FEEDE4009FA0AE /* NSFont+withWeight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4DAAAD29FEEDE4009FA0AE /* NSFont+withWeight.swift */; };
 		5F5338B32960B23200C1D9AE /* ReplaceCharactersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5338B22960B23200C1D9AE /* ReplaceCharactersTests.swift */; };
+		5F6F8F602A0033DF00FB3414 /* FontService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6F8F5F2A0033DF00FB3414 /* FontService.swift */; };
 		5F74B959294F5DD900DE1909 /* StatusPrivacyPreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F74B958294F5DD900DE1909 /* StatusPrivacyPreferencesView.swift */; };
 		5F74B95A294F5DD900DE1909 /* StatusPrivacyPreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F74B958294F5DD900DE1909 /* StatusPrivacyPreferencesView.swift */; };
 		5F8C133C2969F1D9007BE2D5 /* Sdifft in Frameworks */ = {isa = PBXBuildFile; productRef = 5F8C133B2969F1D9007BE2D5 /* Sdifft */; };
@@ -995,6 +996,7 @@
 		5F3BC8B129D0B44000CEBD7F /* SparklineTableCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparklineTableCellView.swift; sourceTree = "<group>"; };
 		5F4DAAAD29FEEDE4009FA0AE /* NSFont+withWeight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSFont+withWeight.swift"; sourceTree = "<group>"; };
 		5F5338B22960B23200C1D9AE /* ReplaceCharactersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaceCharactersTests.swift; sourceTree = "<group>"; };
+		5F6F8F5F2A0033DF00FB3414 /* FontService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontService.swift; sourceTree = "<group>"; };
 		5F74B958294F5DD900DE1909 /* StatusPrivacyPreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusPrivacyPreferencesView.swift; sourceTree = "<group>"; };
 		5F8C1346296A0661007BE2D5 /* EditedStatusTableCellView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EditedStatusTableCellView.xib; sourceTree = "<group>"; };
 		5F8C1348296A06E3007BE2D5 /* EditedStatusTableCellView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditedStatusTableCellView.swift; sourceTree = "<group>"; };
@@ -1717,6 +1719,7 @@
 				5F176FAE290EF65200DF043C /* FollowedListsService.swift */,
 				15769BB622B83C8300E93712 /* PollService.swift */,
 				15E973C4225A6B44009CE4DF /* RelationshipsService.swift */,
+				5F6F8F5F2A0033DF00FB3414 /* FontService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -2846,6 +2849,7 @@
 				15B25D0A2651CBAC00C90963 /* FilterEditorWindowController.swift in Sources */,
 				152DA64721E3F46B0065CC1B /* ResourcesFetcher.swift in Sources */,
 				15E7452922372001009A1252 /* SVGKImage+Helpers.swift in Sources */,
+				5F6F8F602A0033DF00FB3414 /* FontService.swift in Sources */,
 				157D266823B25F8600B3A8BE /* StatusCellModel.swift in Sources */,
 				15E7453022372806009A1252 /* AccountAvatarItem.swift in Sources */,
 				153B23912345763F00A317A2 /* MenuItemFactory.swift in Sources */,

--- a/Mastonaut.xcodeproj/project.pbxproj
+++ b/Mastonaut.xcodeproj/project.pbxproj
@@ -507,6 +507,8 @@
 		5F043C54293286110095C702 /* NotificationTypeFilterPreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F043C52293286110095C702 /* NotificationTypeFilterPreferencesView.swift */; };
 		5F043C562932872D0095C702 /* NotificationPerAccountPreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F043C552932872D0095C702 /* NotificationPerAccountPreferencesView.swift */; };
 		5F043C572932872D0095C702 /* NotificationPerAccountPreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F043C552932872D0095C702 /* NotificationPerAccountPreferencesView.swift */; };
+		5F053A8229F0795E00E2FC8F /* AppearancePreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F053A8129F078BE00E2FC8F /* AppearancePreferencesView.swift */; };
+		5F053A8529F07B3200E2FC8F /* FontPicker in Frameworks */ = {isa = PBXBuildFile; productRef = 5F053A8429F07B3200E2FC8F /* FontPicker */; };
 		5F176FAC290EF03900DF043C /* FollowedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F176FAB290EF03900DF043C /* FollowedList.swift */; };
 		5F176FAF290EF65200DF043C /* FollowedListsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F176FAE290EF65200DF043C /* FollowedListsService.swift */; };
 		5F1F20D62938E86D0057E585 /* LoggingOSLog in Frameworks */ = {isa = PBXBuildFile; productRef = 5F1F20D52938E86D0057E585 /* LoggingOSLog */; };
@@ -531,7 +533,7 @@
 		5FC21CF629C6820500A582A8 /* HashtagSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FC21CF529C6820500A582A8 /* HashtagSearchService.swift */; };
 		5FC21D0129CA55B400A582A8 /* HashtagSuggestionWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5FC21D0029CA511300A582A8 /* HashtagSuggestionWindowController.xib */; };
 		5FC21D0329CA59EF00A582A8 /* DSFSparkline in Frameworks */ = {isa = PBXBuildFile; productRef = 5FC21D0229CA59EF00A582A8 /* DSFSparkline */; };
-		5FC3E1922926FD640086DCEE /* AppearancePreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FC3E1912926FD640086DCEE /* AppearancePreferencesView.swift */; };
+		5FC3E1922926FD640086DCEE /* FontSizePreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FC3E1912926FD640086DCEE /* FontSizePreferencesView.swift */; };
 		5FC3E1952927018A0086DCEE /* LoggingOSLog in Frameworks */ = {isa = PBXBuildFile; productRef = 5FC3E1942927018A0086DCEE /* LoggingOSLog */; };
 		5FD008EB29CBA8C700EC4A29 /* AccountSuggestionWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5FD008EA29CBA8C700EC4A29 /* AccountSuggestionWindowController.xib */; };
 		5FD008EF29CBAB7000EC4A29 /* RedrawsOnSelectTableRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD008EE29CBAB7000EC4A29 /* RedrawsOnSelectTableRowView.swift */; };
@@ -981,6 +983,7 @@
 		5F043C52293286110095C702 /* NotificationTypeFilterPreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTypeFilterPreferencesView.swift; sourceTree = "<group>"; };
 		5F043C552932872D0095C702 /* NotificationPerAccountPreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationPerAccountPreferencesView.swift; sourceTree = "<group>"; };
 		5F043C582933A8D30095C702 /* Mastonaut 10.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Mastonaut 10.xcdatamodel"; sourceTree = "<group>"; };
+		5F053A8129F078BE00E2FC8F /* AppearancePreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearancePreferencesView.swift; sourceTree = "<group>"; };
 		5F176FAB290EF03900DF043C /* FollowedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowedList.swift; sourceTree = "<group>"; };
 		5F176FAD290EF4AD00DF043C /* Mastonaut 8.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Mastonaut 8.xcdatamodel"; sourceTree = "<group>"; };
 		5F176FAE290EF65200DF043C /* FollowedListsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowedListsService.swift; sourceTree = "<group>"; };
@@ -999,7 +1002,7 @@
 		5FC21CF529C6820500A582A8 /* HashtagSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashtagSearchService.swift; sourceTree = "<group>"; };
 		5FC21D0029CA511300A582A8 /* HashtagSuggestionWindowController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HashtagSuggestionWindowController.xib; sourceTree = "<group>"; };
 		5FC3E18E2926F0E80086DCEE /* Logger+CurrentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Logger+CurrentType.swift"; sourceTree = "<group>"; };
-		5FC3E1912926FD640086DCEE /* AppearancePreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearancePreferencesView.swift; sourceTree = "<group>"; };
+		5FC3E1912926FD640086DCEE /* FontSizePreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontSizePreferencesView.swift; sourceTree = "<group>"; };
 		5FD008EA29CBA8C700EC4A29 /* AccountSuggestionWindowController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AccountSuggestionWindowController.xib; sourceTree = "<group>"; };
 		5FD008EE29CBAB7000EC4A29 /* RedrawsOnSelectTableRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RedrawsOnSelectTableRowView.swift; sourceTree = "<group>"; };
 		5FE72EAD292982F0001C7A6C /* BuildConfig.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = BuildConfig.sh; sourceTree = "<group>"; };
@@ -1053,6 +1056,7 @@
 				1596DB46235F65D300B349B7 /* DirectoryService.framework in Frameworks */,
 				15765563229692C200783FFE /* AVKit.framework in Frameworks */,
 				5F8C133C2969F1D9007BE2D5 /* Sdifft in Frameworks */,
+				5F053A8529F07B3200E2FC8F /* FontPicker in Frameworks */,
 				154478A6232B0223009C71D4 /* CoreTootin.framework in Frameworks */,
 				8018496C90237DCCDED54D8E /* Pods_Mastonaut.framework in Frameworks */,
 				5FE7A535292E711100F7EB73 /* PullRefreshableScrollView.framework in Frameworks */,
@@ -1832,9 +1836,10 @@
 		5FC3E1902926FD520086DCEE /* Preferences */ = {
 			isa = PBXGroup;
 			children = (
-				5FC3E1912926FD640086DCEE /* AppearancePreferencesView.swift */,
-				5F043C52293286110095C702 /* NotificationTypeFilterPreferencesView.swift */,
+				5F053A8129F078BE00E2FC8F /* AppearancePreferencesView.swift */,
+				5FC3E1912926FD640086DCEE /* FontSizePreferencesView.swift */,
 				5F043C552932872D0095C702 /* NotificationPerAccountPreferencesView.swift */,
+				5F043C52293286110095C702 /* NotificationTypeFilterPreferencesView.swift */,
 				5F74B958294F5DD900DE1909 /* StatusPrivacyPreferencesView.swift */,
 			);
 			path = Preferences;
@@ -2002,6 +2007,7 @@
 			name = Mastonaut;
 			packageProductDependencies = (
 				5F8C133B2969F1D9007BE2D5 /* Sdifft */,
+				5F053A8429F07B3200E2FC8F /* FontPicker */,
 			);
 			productName = Sengi;
 			productReference = 15C4DD0C21D41EC0002AF6DA /* Mastonaut.app */;
@@ -2082,6 +2088,7 @@
 				5FC3E18B2926EF3F0086DCEE /* XCRemoteSwiftPackageReference "swift-log-oslog" */,
 				5F8C133A2969F1D9007BE2D5 /* XCRemoteSwiftPackageReference "Sdifft" */,
 				5FC21CFD29CA360A00A582A8 /* XCRemoteSwiftPackageReference "DSFSparkline" */,
+				5F053A8329F07B3200E2FC8F /* XCRemoteSwiftPackageReference "FontPicker" */,
 			);
 			productRefGroup = 15C4DD0D21D41EC0002AF6DA /* Products */;
 			projectDirPath = "";
@@ -2791,6 +2798,7 @@
 				15CB8A5B2288CDB100E465D8 /* GeneralPreferencesController.swift in Sources */,
 				1599F8EB22CABA0B00A53D93 /* StatusSearchResultViewController.swift in Sources */,
 				15C78372221CBD8600402C66 /* TimelinesViewController.swift in Sources */,
+				5F053A8229F0795E00E2FC8F /* AppearancePreferencesView.swift in Sources */,
 				1519EBD722A72122007AB87F /* IndexPath+Helpers.swift in Sources */,
 				151D8817230DEA62002583D3 /* BaseAccountsPreferencesViewController.swift in Sources */,
 				15DC02E1225979C0008407A6 /* AccountReference.swift in Sources */,
@@ -2896,7 +2904,7 @@
 				155B9389237A23E5006EBF3C /* AnyObject+Helpers.swift in Sources */,
 				15BB378C22A854880094B5A3 /* EmphasizedTextField.m in Sources */,
 				5F1F20D92938E9140057E585 /* Logger+CurrentType.swift in Sources */,
-				5FC3E1922926FD640086DCEE /* AppearancePreferencesView.swift in Sources */,
+				5FC3E1922926FD640086DCEE /* FontSizePreferencesView.swift in Sources */,
 				15D3B9C824A298CB00DC3B10 /* BPAnimatedImageLayer.swift in Sources */,
 				152DA63F21E23FD30065CC1B /* String+HTMLEntities.swift in Sources */,
 				15C4DD1021D41EC0002AF6DA /* AppDelegate.swift in Sources */,
@@ -3716,6 +3724,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		5F053A8329F07B3200E2FC8F /* XCRemoteSwiftPackageReference "FontPicker" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/tyagishi/FontPicker.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
 		5F8C133A2969F1D9007BE2D5 /* XCRemoteSwiftPackageReference "Sdifft" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/wzxhahaha/Sdifft";
@@ -3743,6 +3759,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		5F053A8429F07B3200E2FC8F /* FontPicker */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5F053A8329F07B3200E2FC8F /* XCRemoteSwiftPackageReference "FontPicker" */;
+			productName = FontPicker;
+		};
 		5F1F20D52938E86D0057E585 /* LoggingOSLog */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 5FC3E18B2926EF3F0086DCEE /* XCRemoteSwiftPackageReference "swift-log-oslog" */;

--- a/Mastonaut.xcodeproj/project.pbxproj
+++ b/Mastonaut.xcodeproj/project.pbxproj
@@ -508,7 +508,6 @@
 		5F043C562932872D0095C702 /* NotificationPerAccountPreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F043C552932872D0095C702 /* NotificationPerAccountPreferencesView.swift */; };
 		5F043C572932872D0095C702 /* NotificationPerAccountPreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F043C552932872D0095C702 /* NotificationPerAccountPreferencesView.swift */; };
 		5F053A8229F0795E00E2FC8F /* AppearancePreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F053A8129F078BE00E2FC8F /* AppearancePreferencesView.swift */; };
-		5F053A8529F07B3200E2FC8F /* FontPicker in Frameworks */ = {isa = PBXBuildFile; productRef = 5F053A8429F07B3200E2FC8F /* FontPicker */; };
 		5F176FAC290EF03900DF043C /* FollowedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F176FAB290EF03900DF043C /* FollowedList.swift */; };
 		5F176FAF290EF65200DF043C /* FollowedListsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F176FAE290EF65200DF043C /* FollowedListsService.swift */; };
 		5F1F20D62938E86D0057E585 /* LoggingOSLog in Frameworks */ = {isa = PBXBuildFile; productRef = 5F1F20D52938E86D0057E585 /* LoggingOSLog */; };
@@ -521,6 +520,7 @@
 		5F3A17F0291DB26700EA6FEC /* CoreAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5F3A17EE291DB26700EA6FEC /* CoreAssets.xcassets */; };
 		5F3A17F1291DB26700EA6FEC /* CoreAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5F3A17EE291DB26700EA6FEC /* CoreAssets.xcassets */; };
 		5F3BC8B229D0B44000CEBD7F /* SparklineTableCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3BC8B129D0B44000CEBD7F /* SparklineTableCellView.swift */; };
+		5F4DAAAC29FDA15E009FA0AE /* FontPicker in Frameworks */ = {isa = PBXBuildFile; productRef = 5F4DAAAB29FDA15E009FA0AE /* FontPicker */; };
 		5F5338B32960B23200C1D9AE /* ReplaceCharactersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5338B22960B23200C1D9AE /* ReplaceCharactersTests.swift */; };
 		5F74B959294F5DD900DE1909 /* StatusPrivacyPreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F74B958294F5DD900DE1909 /* StatusPrivacyPreferencesView.swift */; };
 		5F74B95A294F5DD900DE1909 /* StatusPrivacyPreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F74B958294F5DD900DE1909 /* StatusPrivacyPreferencesView.swift */; };
@@ -1056,7 +1056,7 @@
 				1596DB46235F65D300B349B7 /* DirectoryService.framework in Frameworks */,
 				15765563229692C200783FFE /* AVKit.framework in Frameworks */,
 				5F8C133C2969F1D9007BE2D5 /* Sdifft in Frameworks */,
-				5F053A8529F07B3200E2FC8F /* FontPicker in Frameworks */,
+				5F4DAAAC29FDA15E009FA0AE /* FontPicker in Frameworks */,
 				154478A6232B0223009C71D4 /* CoreTootin.framework in Frameworks */,
 				8018496C90237DCCDED54D8E /* Pods_Mastonaut.framework in Frameworks */,
 				5FE7A535292E711100F7EB73 /* PullRefreshableScrollView.framework in Frameworks */,
@@ -2007,7 +2007,7 @@
 			name = Mastonaut;
 			packageProductDependencies = (
 				5F8C133B2969F1D9007BE2D5 /* Sdifft */,
-				5F053A8429F07B3200E2FC8F /* FontPicker */,
+				5F4DAAAB29FDA15E009FA0AE /* FontPicker */,
 			);
 			productName = Sengi;
 			productReference = 15C4DD0C21D41EC0002AF6DA /* Mastonaut.app */;
@@ -2088,7 +2088,7 @@
 				5FC3E18B2926EF3F0086DCEE /* XCRemoteSwiftPackageReference "swift-log-oslog" */,
 				5F8C133A2969F1D9007BE2D5 /* XCRemoteSwiftPackageReference "Sdifft" */,
 				5FC21CFD29CA360A00A582A8 /* XCRemoteSwiftPackageReference "DSFSparkline" */,
-				5F053A8329F07B3200E2FC8F /* XCRemoteSwiftPackageReference "FontPicker" */,
+				5F4DAAAA29FDA15E009FA0AE /* XCRemoteSwiftPackageReference "FontPicker" */,
 			);
 			productRefGroup = 15C4DD0D21D41EC0002AF6DA /* Products */;
 			projectDirPath = "";
@@ -3724,12 +3724,12 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		5F053A8329F07B3200E2FC8F /* XCRemoteSwiftPackageReference "FontPicker" */ = {
+		5F4DAAAA29FDA15E009FA0AE /* XCRemoteSwiftPackageReference "FontPicker" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/tyagishi/FontPicker.git";
+			repositoryURL = "https://github.com/chucker/FontPicker.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				branch = main;
+				kind = branch;
 			};
 		};
 		5F8C133A2969F1D9007BE2D5 /* XCRemoteSwiftPackageReference "Sdifft" */ = {
@@ -3759,15 +3759,15 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		5F053A8429F07B3200E2FC8F /* FontPicker */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 5F053A8329F07B3200E2FC8F /* XCRemoteSwiftPackageReference "FontPicker" */;
-			productName = FontPicker;
-		};
 		5F1F20D52938E86D0057E585 /* LoggingOSLog */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 5FC3E18B2926EF3F0086DCEE /* XCRemoteSwiftPackageReference "swift-log-oslog" */;
 			productName = LoggingOSLog;
+		};
+		5F4DAAAB29FDA15E009FA0AE /* FontPicker */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 5F4DAAAA29FDA15E009FA0AE /* XCRemoteSwiftPackageReference "FontPicker" */;
+			productName = FontPicker;
 		};
 		5F8C133B2969F1D9007BE2D5 /* Sdifft */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Mastonaut.xcodeproj/project.pbxproj
+++ b/Mastonaut.xcodeproj/project.pbxproj
@@ -521,6 +521,7 @@
 		5F3A17F1291DB26700EA6FEC /* CoreAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5F3A17EE291DB26700EA6FEC /* CoreAssets.xcassets */; };
 		5F3BC8B229D0B44000CEBD7F /* SparklineTableCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F3BC8B129D0B44000CEBD7F /* SparklineTableCellView.swift */; };
 		5F4DAAAC29FDA15E009FA0AE /* FontPicker in Frameworks */ = {isa = PBXBuildFile; productRef = 5F4DAAAB29FDA15E009FA0AE /* FontPicker */; };
+		5F4DAAAE29FEEDE4009FA0AE /* NSFont+withWeight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4DAAAD29FEEDE4009FA0AE /* NSFont+withWeight.swift */; };
 		5F5338B32960B23200C1D9AE /* ReplaceCharactersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5338B22960B23200C1D9AE /* ReplaceCharactersTests.swift */; };
 		5F74B959294F5DD900DE1909 /* StatusPrivacyPreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F74B958294F5DD900DE1909 /* StatusPrivacyPreferencesView.swift */; };
 		5F74B95A294F5DD900DE1909 /* StatusPrivacyPreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F74B958294F5DD900DE1909 /* StatusPrivacyPreferencesView.swift */; };
@@ -992,6 +993,7 @@
 		5F38B52E2930301600FCB9FC /* PullToRefreshInnerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PullToRefreshInnerView.swift; sourceTree = "<group>"; };
 		5F3A17EE291DB26700EA6FEC /* CoreAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = CoreAssets.xcassets; sourceTree = "<group>"; };
 		5F3BC8B129D0B44000CEBD7F /* SparklineTableCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparklineTableCellView.swift; sourceTree = "<group>"; };
+		5F4DAAAD29FEEDE4009FA0AE /* NSFont+withWeight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSFont+withWeight.swift"; sourceTree = "<group>"; };
 		5F5338B22960B23200C1D9AE /* ReplaceCharactersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaceCharactersTests.swift; sourceTree = "<group>"; };
 		5F74B958294F5DD900DE1909 /* StatusPrivacyPreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusPrivacyPreferencesView.swift; sourceTree = "<group>"; };
 		5F8C1346296A0661007BE2D5 /* EditedStatusTableCellView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EditedStatusTableCellView.xib; sourceTree = "<group>"; };
@@ -1200,6 +1202,7 @@
 				15E7452822372001009A1252 /* SVGKImage+Helpers.swift */,
 				15431283232EEB960010854A /* UserPopUpButtonController+Helper.swift */,
 				5F38B52B29302F0C00FCB9FC /* AppKitSwiftUIIntegration.swift */,
+				5F4DAAAD29FEEDE4009FA0AE /* NSFont+withWeight.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2847,6 +2850,7 @@
 				15E7453022372806009A1252 /* AccountAvatarItem.swift in Sources */,
 				153B23912345763F00A317A2 /* MenuItemFactory.swift in Sources */,
 				15077EE22231DB9700965651 /* RemoteEventsListener.swift in Sources */,
+				5F4DAAAE29FEEDE4009FA0AE /* NSFont+withWeight.swift in Sources */,
 				1594392F229991F200E47DBB /* InstanceTableCellView.swift in Sources */,
 				5F043C562932872D0095C702 /* NotificationPerAccountPreferencesView.swift in Sources */,
 				15ECEECE22E8EEAB00A37CC0 /* LazyEvaluationAdapter.swift in Sources */,

--- a/Mastonaut.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mastonaut.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -12,10 +12,10 @@
     {
       "identity" : "fontpicker",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tyagishi/FontPicker.git",
+      "location" : "https://github.com/chucker/FontPicker.git",
       "state" : {
-        "revision" : "2ed54bec5fbd3c7284ced388c63b80b8950473f3",
-        "version" : "1.0.0"
+        "branch" : "main",
+        "revision" : "c3d15a549a9436b406466cfa552540db95888ffe"
       }
     },
     {

--- a/Mastonaut.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Mastonaut.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "fontpicker",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tyagishi/FontPicker.git",
+      "state" : {
+        "revision" : "2ed54bec5fbd3c7284ced388c63b80b8950473f3",
+        "version" : "1.0.0"
+      }
+    },
+    {
       "identity" : "sdifft",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wzxhahaha/Sdifft",

--- a/Mastonaut/Extensions/NSFont+withWeight.swift
+++ b/Mastonaut/Extensions/NSFont+withWeight.swift
@@ -1,0 +1,50 @@
+//
+//  NSFont+withWeight.swift
+//  Mastonaut
+//
+//  Created by Sören Kuklau on 30.04.23.
+//  Copyright © 2023 Bruno Philipe. All rights reserved.
+//
+
+import AppKit
+import Foundation
+
+extension NSFont
+{
+	/// Rough mapping from behavior of `.systemFont(…weight:)`
+	/// to `NSFontManager`'s `Int`-based weight,
+	/// as of 13.4 Ventura
+	func withWeight(weight: NSFont.Weight) -> NSFont?
+	{
+		let fontManager=NSFontManager.shared
+
+		var intWeight: Int
+
+		switch weight
+		{
+		case .ultraLight:
+			intWeight=0
+		case .light:
+			intWeight=2 // treated as ultraLight
+		case .thin:
+			intWeight=3
+		case .medium:
+			intWeight=6
+		case .semibold:
+			intWeight=8 // treated as bold
+		case .bold:
+			intWeight=9
+		case .heavy:
+			intWeight=10 // treated as bold
+		case .black:
+			intWeight=15 // .systemFont does bold here; we do condensed black
+		default:
+			intWeight=5 // treated as regular
+		}
+
+		return fontManager.font(withFamily: self.familyName ?? "",
+		                        traits: .unboldFontMask,
+		                        weight: intWeight,
+		                        size: self.pointSize)
+	}
+}

--- a/Mastonaut/Models/StatusCellModel.swift
+++ b/Mastonaut/Models/StatusCellModel.swift
@@ -25,7 +25,11 @@ class StatusCellModel: NSObject
 {
 	let status: Status
 
+	let poll: Poll?
+
+	unowned let attachmentPresenter: AttachmentPresenting
 	unowned let interactionHandler: StatusInteractionHandling
+	unowned let activeInstance: Instance
 
 	@objc private(set) dynamic
 	var isFavorited: Bool
@@ -57,10 +61,19 @@ class StatusCellModel: NSObject
 		return status.account
 	}
 
-	init(status: Status, interactionHandler: StatusInteractionHandling)
+	init(status: Status,
+	     poll: Poll?,
+	     attachmentPresenter: AttachmentPresenting,
+	     interactionHandler: StatusInteractionHandling,
+	     activeInstance: Instance)
 	{
 		self.status = status
+
+		self.poll = poll
+
+		self.attachmentPresenter = attachmentPresenter
 		self.interactionHandler = interactionHandler
+		self.activeInstance = activeInstance
 
 		self.isFavorited = status.favourited == true
 		self.isReblogged = status.reblogged == true
@@ -99,8 +112,8 @@ class StatusCellModel: NSObject
 		{
 			contextIcon = #imageLiteral(resourceName: "retooted")
 			button.set(stringValue: 🔠("status.context.boost", agent.bestDisplayName),
-					   applyingAttributes: attributes,
-					   applyingEmojis: agent.cacheableEmojis)
+			           applyingAttributes: attributes,
+			           applyingEmojis: agent.cacheableEmojis)
 			button.isEnabled = true
 		}
 		else if status.inReplyToAccountID == status.account.id
@@ -226,13 +239,13 @@ class StatusCellModel: NSObject
 extension StatusCellModel: PollViewControllerDelegate
 {
 	func pollViewController(_ viewController: PollViewController,
-							userDidVote optionIndexSet: IndexSet,
-							completion: @escaping (Poll?) -> Void)
+	                        userDidVote optionIndexSet: IndexSet,
+	                        completion: @escaping (Poll?) -> Void)
 	{
 		guard let poll = viewController.poll else { return }
 
 		interactionHandler.voteOn(poll: poll,
-								  statusID: visibleStatus.id,
+		                          statusID: visibleStatus.id,
 		                          options: optionIndexSet)
 		{ [weak self] result in
 			switch result

--- a/Mastonaut/Models/StatusCellModel.swift
+++ b/Mastonaut/Models/StatusCellModel.swift
@@ -17,9 +17,9 @@
 //  GNU General Public License for more details.
 //
 
+import CoreTootin
 import Foundation
 import MastodonKit
-import CoreTootin
 
 class StatusCellModel: NSObject
 {
@@ -27,20 +27,20 @@ class StatusCellModel: NSObject
 
 	unowned let interactionHandler: StatusInteractionHandling
 
-	@objc dynamic
-	private(set) var isFavorited: Bool
+	@objc private(set) dynamic
+	var isFavorited: Bool
 
-	@objc dynamic
-	private(set) var isReblogged: Bool
+	@objc private(set) dynamic
+	var isReblogged: Bool
 
-	@objc dynamic
-	private(set) var authorAvatar: NSImage
+	@objc private(set) dynamic
+	var authorAvatar: NSImage
 
-	@objc dynamic
-	private(set) var agentAvatar: NSImage? = nil
+	@objc private(set) dynamic
+	var agentAvatar: NSImage?
 
-	@objc dynamic
-	private(set) var contextIcon: NSImage? = nil
+	@objc private(set) dynamic
+	var contextIcon: NSImage?
 
 	var visibleStatus: Status
 	{
@@ -65,7 +65,7 @@ class StatusCellModel: NSObject
 		self.isFavorited = status.favourited == true
 		self.isReblogged = status.reblogged == true
 
-		authorAvatar = #imageLiteral(resourceName: "missing")
+		self.authorAvatar = #imageLiteral(resourceName: "missing")
 
 		super.init()
 
@@ -182,8 +182,10 @@ class StatusCellModel: NSObject
 
 	func loadAccountAvatar(for status: Status, completion: @escaping (NSImage) -> Void)
 	{
-		AppDelegate.shared.avatarImageCache.fetchImage(account: status.account) { result in
-			switch result {
+		AppDelegate.shared.avatarImageCache.fetchImage(account: status.account)
+		{ result in
+			switch result
+			{
 			case .inCache(let avatarImage):
 				assert(Thread.isMainThread)
 				completion(avatarImage)
@@ -231,8 +233,8 @@ extension StatusCellModel: PollViewControllerDelegate
 
 		interactionHandler.voteOn(poll: poll,
 								  statusID: visibleStatus.id,
-								  options: optionIndexSet) { [weak self] result in
-
+		                          options: optionIndexSet)
+		{ [weak self] result in
 			switch result
 			{
 			case .success(let updatedPoll):
@@ -240,7 +242,8 @@ extension StatusCellModel: PollViewControllerDelegate
 
 			case .failure(let error):
 				completion(nil)
-				DispatchQueue.main.async {
+				DispatchQueue.main.async
+				{
 					self?.interactionHandler.handle(interactionError: UserLocalizedDescriptionError(error))
 				}
 			}

--- a/Mastonaut/Services/FontService.swift
+++ b/Mastonaut/Services/FontService.swift
@@ -10,6 +10,14 @@ import Cocoa
 import CoreTootin
 
 struct FontService {
+	/// The base font, whose family and size is used. This is typically
+	/// either the default, or a font picked from the preferences, where
+	/// regular and focused statuses can be configured separately (for
+	/// example, a focused status is by default larger).
+	///
+	/// Note that this type does not support relative font size changes.
+	/// Previously, for example, `bio` was smaller than `status`. At
+	/// some point in the future, we may want to address that.
 	init(font: NSFont) {
 		self.font = font
 	}
@@ -20,6 +28,34 @@ struct FontService {
 		return [
 			.foregroundColor: NSColor.labelColor,
 			.font: font.withWeight(weight: .semibold)!
+		]
+	}
+	
+	public func favoriteAttributes() -> [NSAttributedString.Key: AnyObject] {
+		return [
+			.foregroundColor: NSColor.statusFavorited,
+			.font: font.withWeight(weight: .medium)!
+		]
+	}
+	
+	public func followAttributes() -> [NSAttributedString.Key: AnyObject] {
+		return [
+			.foregroundColor: NSColor.labelColor,
+			.font: font.withWeight(weight: .medium)!
+		]
+	}
+	
+	public func interactionAttributes() -> [NSAttributedString.Key: AnyObject] {
+		return [
+			.foregroundColor: NSColor.labelColor,
+			.font: font.withWeight(weight: .medium)!
+		]
+	}
+	
+	public func reblogAttributes() -> [NSAttributedString.Key: AnyObject] {
+		return [
+			.foregroundColor: NSColor.statusReblogged,
+			.font: font.withWeight(weight: .medium)!
 		]
 	}
 	
@@ -35,6 +71,23 @@ struct FontService {
 	public func statusLinkAttributes() -> [NSAttributedString.Key: AnyObject] {
 		return [
 			.foregroundColor: NSColor.safeControlTintColor,
+			.font: font.withWeight(weight: .medium)!,
+			.underlineStyle: NSNumber(value: 1)
+		]
+	}
+	
+	public func userBioAttributes() -> [NSAttributedString.Key: AnyObject] {
+		return [
+			.foregroundColor: NSColor.labelColor,
+			.font: font,
+			.underlineStyle: NSNumber(value: 0) // <-- This is a hack to prevent the label's contents from shifting
+											 // vertically when clicked.
+		]
+	}
+	
+	public func userBioLinkAttributes() -> [NSAttributedString.Key: AnyObject] {
+		return [
+			.foregroundColor: NSColor.labelColor,
 			.font: font.withWeight(weight: .medium)!,
 			.underlineStyle: NSNumber(value: 1)
 		]

--- a/Mastonaut/Services/FontService.swift
+++ b/Mastonaut/Services/FontService.swift
@@ -1,0 +1,42 @@
+//
+//  FontService.swift
+//  Mastonaut
+//
+//  Created by Sören Kuklau on 01.05.23.
+//  Copyright © 2023 Bruno Philipe. All rights reserved.
+//
+
+import Cocoa
+import CoreTootin
+
+struct FontService {
+	init(font: NSFont) {
+		self.font = font
+	}
+
+	let font: NSFont
+
+	public func authorAttributes() -> [NSAttributedString.Key: AnyObject] {
+		return [
+			.foregroundColor: NSColor.labelColor,
+			.font: font.withWeight(weight: .semibold)!
+		]
+	}
+	
+	public func statusAttributes() -> [NSAttributedString.Key: AnyObject] {
+		return [
+			.foregroundColor: NSColor.labelColor,
+			.font: font,
+			.underlineStyle: NSNumber(value: 0) // <-- This is a hack to prevent the label's contents from shifting
+			// vertically when clicked.
+		]
+	}
+	
+	public func statusLinkAttributes() -> [NSAttributedString.Key: AnyObject] {
+		return [
+			.foregroundColor: NSColor.safeControlTintColor,
+			.font: font.withWeight(weight: .medium)!,
+			.underlineStyle: NSNumber(value: 1)
+		]
+	}
+}

--- a/Mastonaut/Storyboards/Preferences.storyboard
+++ b/Mastonaut/Storyboards/Preferences.storyboard
@@ -262,12 +262,15 @@
             <objects>
                 <viewController title="Viewing" showSeguePresentationStyle="single" id="mSD-jq-ByT" customClass="ViewingPreferencesController" customModule="Mastonaut" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="gkN-wI-pe6">
-                        <rect key="frame" x="0.0" y="0.0" width="670" height="326"/>
+                        <rect key="frame" x="0.0" y="0.0" width="670" height="442"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="20" horizontalStackHuggingPriority="250.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalCompressionResistancePriority="250" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dnI-9D-en5">
-                                <rect key="frame" x="20" y="20" width="630" height="286"/>
+                                <rect key="frame" x="20" y="20" width="630" height="402"/>
                                 <subviews>
+                                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="NvV-3Y-5m8" customClass="NSHostingView">
+                                        <rect key="frame" x="0.0" y="306" width="630" height="96"/>
+                                    </customView>
                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="0wY-1I-Ecj">
                                         <rect key="frame" x="0.0" y="188" width="630" height="98"/>
                                         <subviews>
@@ -486,8 +489,10 @@
                                     <integer value="1000"/>
                                     <integer value="1000"/>
                                     <integer value="1000"/>
+                                    <integer value="1000"/>
                                 </visibilityPriorities>
                                 <customSpacing>
+                                    <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
                                     <real value="3.4028234663852886e+38"/>
@@ -503,6 +508,7 @@
                     </view>
                     <connections>
                         <outlet property="autoplayVideosButton" destination="K31-xF-mvG" id="Xjr-k2-Oj2"/>
+                        <outlet property="fontSizePreferencesView" destination="NvV-3Y-5m8" id="T9T-WK-gqA"/>
                         <outlet property="sensitiveMediaAlwaysHideButton" destination="vhm-7l-6wD" id="9kp-oO-4gS"/>
                         <outlet property="sensitiveMediaAlwaysRevealButton" destination="lGi-pK-3BJ" id="YEM-zV-Ecy"/>
                         <outlet property="sensitiveMediaHideSensitiveButton" destination="9AT-Bt-cW1" id="mBE-Xv-LIN"/>
@@ -1343,7 +1349,7 @@
                                                     <rect key="frame" x="17" y="17" width="348" height="226"/>
                                                     <clipView key="contentView" id="fSM-pz-NUz">
                                                         <rect key="frame" x="1" y="1" width="346" height="224"/>
-                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                        <autoresizingMask key="autoresizingMask"/>
                                                         <subviews>
                                                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="24" rowSizeStyle="systemDefault" headerView="GrU-US-sWU" viewBased="YES" id="ugb-tz-1iA">
                                                                 <rect key="frame" x="0.0" y="0.0" width="346" height="174"/>

--- a/Mastonaut/View Controllers/Global Search/StatusSearchResultViewController.swift
+++ b/Mastonaut/View Controllers/Global Search/StatusSearchResultViewController.swift
@@ -56,16 +56,12 @@ class StatusSearchResultsViewController: SearchResultsViewController<Status>
 
 class StatusResultTableCellView: NSTableCellView
 {
-	/// A lot of this code is just copied from `StatusTableCellView` and should probably be abstracted out
-	private static let _authorLabelAttributes: [NSAttributedString.Key: AnyObject] = [
-		.foregroundColor: NSColor.labelColor, .font: NSFont.systemFont(ofSize: 14, weight: .semibold)
-	]
+	/// Some of this code is just copied from `StatusTableCellView` and should probably be abstracted out
 
-	private static let _statusLabelAttributes: [NSAttributedString.Key: AnyObject] = [
-		.foregroundColor: NSColor.labelColor, .font: NSFont.labelFont(ofSize: 14),
-		.underlineStyle: NSNumber(value: 0) // <-- This is a hack to prevent the label's contents from shifting
-		// vertically when clicked.
-	]
+	private func fontService() -> FontService
+	{
+		return FontService(font: MastonautPreferences.instance.statusFont)
+	}
 
 	@IBOutlet var avatarImageView: NSButton!
 	@IBOutlet private unowned var authorNameButton: NSButton!
@@ -105,7 +101,7 @@ class StatusResultTableCellView: NSTableCellView
 		super.awakeFromNib()
 
 		timeLabel.formatter = RelativeDateFormatter.shared
-		
+
 		// https://github.com/chucker/Mastonaut/issues/79 unclear why needed (otherwise set to pink)
 		contentWarningLabel.backgroundColor = NSColor.clear
 		statusLabel.backgroundColor = NSColor.clear
@@ -139,7 +135,7 @@ class StatusResultTableCellView: NSTableCellView
 		}
 
 		authorNameButton.set(stringValue: status.authorName,
-		                     applyingAttributes: StatusResultTableCellView._authorLabelAttributes,
+		                     applyingAttributes: fontService().authorAttributes(),
 		                     applyingEmojis: status.account.cacheableEmojis)
 
 		authorAccountLabel.stringValue = status.account.uri(in: instance)
@@ -158,7 +154,7 @@ class StatusResultTableCellView: NSTableCellView
 		}
 
 		statusLabel.set(attributedStringValue: statusString,
-		                applyingAttributes: StatusResultTableCellView._statusLabelAttributes,
+		                applyingAttributes: fontService().statusAttributes(),
 		                applyingEmojis: status.cacheableEmojis)
 
 		if status.mediaAttachments.count > 0
@@ -189,7 +185,7 @@ class StatusResultTableCellView: NSTableCellView
 
 			warningButton.isHidden = false
 			contentWarningLabel.set(attributedStringValue: status.attributedSpoiler,
-			                        applyingAttributes: StatusResultTableCellView._statusLabelAttributes,
+			                        applyingAttributes: fontService().statusAttributes(),
 			                        applyingEmojis: status.cacheableEmojis)
 			installSpoilerCover()
 			contentWarningContainer.isHidden = false

--- a/Mastonaut/View Controllers/Preferences/ViewingPreferencesController.swift
+++ b/Mastonaut/View Controllers/Preferences/ViewingPreferencesController.swift
@@ -22,6 +22,8 @@ import CoreTootin
 
 class ViewingPreferencesController: NSViewController
 {
+	@IBOutlet weak var fontSizePreferencesView: NSView!
+	
 	@IBOutlet private weak var sensitiveMediaHideSensitiveButton: NSButton!
 	@IBOutlet private weak var sensitiveMediaAlwaysRevealButton: NSButton!
 	@IBOutlet private weak var sensitiveMediaAlwaysHideButton: NSButton!
@@ -37,6 +39,9 @@ class ViewingPreferencesController: NSViewController
 	override func viewDidLoad()
 	{
 		super.viewDidLoad()
+		
+		let fontSizeView = FontSizePreferencesView()
+		AppKitSwiftUIIntegration.hostSwiftUIView(fontSizeView, inView: fontSizePreferencesView)
 
 		let sensitiveMediaButtonMap: [MastonautPreferences.MediaDisplayMode: NSButton] = [
 			.alwaysHide: sensitiveMediaAlwaysHideButton,

--- a/Mastonaut/Views/Preferences/FontSizePreferencesView.swift
+++ b/Mastonaut/Views/Preferences/FontSizePreferencesView.swift
@@ -11,8 +11,8 @@ import FontPicker
 import SwiftUI
 
 struct FontSizePreferencesView: View {
-	@State private var timelineFont: NSFont = MastonautPreferences.instance.timelineFont
-	@State private var focusedFont: NSFont = MastonautPreferences.instance.focusedFont
+	@State private var statusFont: NSFont = MastonautPreferences.instance.statusFont
+	@State private var focusedStatusFont: NSFont = MastonautPreferences.instance.focusedStatusFont
 
 	let columns = [
 		GridItem(.fixed(260), alignment: .trailing),
@@ -21,35 +21,37 @@ struct FontSizePreferencesView: View {
 
 	var body: some View {
 		LazyVGrid(columns: columns) {
-			Text("Timeline status font size:")
+			Text("Status font size:")
 
 			HStack {
-				FontPicker("", selection: $timelineFont)
+				FontPicker("", selection: $statusFont)
 					.padding(.leading, -7) // FontPicker shows its own label, which we don't want
 
 				Button("Reset") {
-					timelineFont = MastonautPreferences.defaultTimelineFont
+					statusFont = MastonautPreferences.defaultStatusFont
 				}
 
-				Text("\(timelineFont.displayName ?? "(no font)") \(timelineFont.pointSize, specifier: "%.0f")")
+				Text("\(statusFont.displayName ?? "(no font)") \(statusFont.pointSize, specifier: "%.0f")")
 			}
 			
-			Text("Conversation status font size:")
+			Text("Focused status font size:")
 
 			HStack {
-				FontPicker("", selection: $focusedFont)
+				FontPicker("", selection: $focusedStatusFont)
 					.padding(.leading, -7) // FontPicker shows its own label, which we don't want
 
-				Button("Reset") {}
+				Button("Reset") {
+					focusedStatusFont = MastonautPreferences.defaultFocusedStatusFont
+				}
 
-				Text("\(focusedFont.displayName ?? "(no font)") \(focusedFont.pointSize, specifier: "%.0f")")
+				Text("\(focusedStatusFont.displayName ?? "(no font)") \(focusedStatusFont.pointSize, specifier: "%.0f")")
 			}
 		}
-		.onChange(of: timelineFont) { newValue in
-			MastonautPreferences.instance.timelineFont = newValue
+		.onChange(of: statusFont) { newValue in
+			MastonautPreferences.instance.statusFont = newValue
 		}
-		.onChange(of: focusedFont) { newValue in
-			MastonautPreferences.instance.focusedFont = newValue
+		.onChange(of: focusedStatusFont) { newValue in
+			MastonautPreferences.instance.focusedStatusFont = newValue
 		}
 		// AppKit layout hacks
 		.padding(.trailing, 15)

--- a/Mastonaut/Views/Preferences/FontSizePreferencesView.swift
+++ b/Mastonaut/Views/Preferences/FontSizePreferencesView.swift
@@ -1,0 +1,64 @@
+//
+//  Appearance.swift
+//  Mastonaut
+//
+//  Created by Sören Kuklau on 18.11.22.
+//  Copyright © 2022 Bruno Philipe. All rights reserved.
+//
+
+import CoreTootin
+import FontPicker
+import SwiftUI
+
+struct FontSizePreferencesView: View {
+	@State private var timelineFont: NSFont = MastonautPreferences.instance.timelineFont
+	@State private var focusedFont: NSFont = MastonautPreferences.instance.focusedFont
+
+	let columns = [
+		GridItem(.fixed(260), alignment: .trailing),
+		GridItem(.fixed(380), alignment: .leading),
+	]
+
+	var body: some View {
+		LazyVGrid(columns: columns) {
+			Text("Timeline status font size:")
+
+			HStack {
+				FontPicker("", selection: $timelineFont)
+					.padding(.leading, -7) // FontPicker shows its own label, which we don't want
+
+				Button("Reset") {
+					timelineFont = MastonautPreferences.defaultTimelineFont
+				}
+
+				Text("\(timelineFont.displayName ?? "(no font)") \(timelineFont.pointSize, specifier: "%.0f")")
+			}
+			
+			Text("Conversation status font size:")
+
+			HStack {
+				FontPicker("", selection: $focusedFont)
+					.padding(.leading, -7) // FontPicker shows its own label, which we don't want
+
+				Button("Reset") {}
+
+				Text("\(focusedFont.displayName ?? "(no font)") \(focusedFont.pointSize, specifier: "%.0f")")
+			}
+		}
+		.onChange(of: timelineFont) { newValue in
+			MastonautPreferences.instance.timelineFont = newValue
+		}
+		.onChange(of: focusedFont) { newValue in
+			MastonautPreferences.instance.focusedFont = newValue
+		}
+		// AppKit layout hacks
+		.padding(.trailing, 15)
+		.frame(minHeight: 70)
+	}
+}
+
+struct FontSizePreferencesView_Previews: PreviewProvider {
+	static var previews: some View {
+		FontSizePreferencesView()
+	}
+}

--- a/Mastonaut/Views/Table Cell Views/EditedStatusTableCellView.swift
+++ b/Mastonaut/Views/Table Cell Views/EditedStatusTableCellView.swift
@@ -37,7 +37,7 @@ class EditedStatusTableCellView: NSTableCellView {
 		self.cellModel = cellModel
 
 		authorNameButton.set(stringValue: status.authorName,
-		                     applyingAttributes: EditedStatusTableCellView._authorLabelAttributes,
+							 applyingAttributes: fontService().authorAttributes(),
 		                     applyingEmojis: status.account.cacheableEmojis)
 
 		authorAccountLabel.stringValue = status.account.uri(in: activeInstance)
@@ -70,13 +70,7 @@ class EditedStatusTableCellView: NSTableCellView {
 			same: [.backgroundColor: NSColor.white]
 		)
 
-	private static let _authorLabelAttributes: [NSAttributedString.Key: AnyObject] = [
-		.foregroundColor: NSColor.labelColor, .font: NSFont.systemFont(ofSize: 14, weight: .semibold)
-	]
-
-	private static let _statusLabelAttributes: [NSAttributedString.Key: AnyObject] = [
-		.foregroundColor: NSColor.labelColor, .font: NSFont.labelFont(ofSize: 14),
-		.underlineStyle: NSNumber(value: 0) // <-- This is a hack to prevent the label's contents from shifting
-		// vertically when clicked.
-	]
+	private func fontService() -> FontService {
+		return FontService(font: MastonautPreferences.instance.statusFont)
+	}
 }

--- a/Mastonaut/Views/Table Cell Views/FocusedStatusTableCellView.swift
+++ b/Mastonaut/Views/Table Cell Views/FocusedStatusTableCellView.swift
@@ -30,16 +30,16 @@ class FocusedStatusTableCellView: StatusTableCellView
 	{
 		super.awakeFromNib()
 
-		MastonautPreferences.instance.addObserver(self, forKeyPath: MastonautPreferences.focusedFontFamilyKey)
-		MastonautPreferences.instance.addObserver(self, forKeyPath: MastonautPreferences.focusedFontSizeKey)
+		MastonautPreferences.instance.addObserver(self, forKeyPath: MastonautPreferences.focusedStatusFontFamilyKey)
+		MastonautPreferences.instance.addObserver(self, forKeyPath: MastonautPreferences.focusedStatusFontSizeKey)
 	}
 
 	override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?)
 	{
 		switch keyPath
 		{
-		case MastonautPreferences.focusedFontFamilyKey,
-		     MastonautPreferences.focusedFontSizeKey:
+		case MastonautPreferences.focusedStatusFontFamilyKey,
+		     MastonautPreferences.focusedStatusFontSizeKey:
 			redraw()
 		default:
 			break
@@ -73,7 +73,7 @@ class FocusedStatusTableCellView: StatusTableCellView
 	{
 		return [
 			.foregroundColor: NSColor.labelColor,
-			.font: MastonautPreferences.instance.focusedFont,
+			.font: MastonautPreferences.instance.focusedStatusFont,
 			.underlineStyle: NSNumber(value: 0) // <-- This is a hack to prevent the label's contents from shifting
 			// vertically when clicked.
 		]

--- a/Mastonaut/Views/Table Cell Views/FocusedStatusTableCellView.swift
+++ b/Mastonaut/Views/Table Cell Views/FocusedStatusTableCellView.swift
@@ -29,21 +29,25 @@ class FocusedStatusTableCellView: StatusTableCellView
 	override func awakeFromNib()
 	{
 		super.awakeFromNib()
+		
+		fontObserver = MastonautPreferences.instance.observe(\.focusedStatusFont, options: .new)
+		{
+			[weak self] _, _ in
+			self?.updateFont()
+		}
+	}
+	
+	private var fontObserver: NSKeyValueObservation?
 
-		MastonautPreferences.instance.addObserver(self, forKeyPath: MastonautPreferences.focusedStatusFontFamilyKey)
-		MastonautPreferences.instance.addObserver(self, forKeyPath: MastonautPreferences.focusedStatusFontSizeKey)
+	deinit
+	{
+		fontObserver?.invalidate()
 	}
 
-	override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?)
+	override func updateFont()
 	{
-		switch keyPath
-		{
-		case MastonautPreferences.focusedStatusFontFamilyKey,
-		     MastonautPreferences.focusedStatusFontSizeKey:
-			redraw()
-		default:
-			break
-		}
+
+		redraw()
 	}
 
 	private var sourceApplication: Application?

--- a/Mastonaut/Views/Table Cell Views/FocusedStatusTableCellView.swift
+++ b/Mastonaut/Views/Table Cell Views/FocusedStatusTableCellView.swift
@@ -43,17 +43,17 @@ class FocusedStatusTableCellView: StatusTableCellView
 		.underlineStyle: NSNumber(value: 1)
 	]
 
-	internal override func authorLabelAttributes() -> [NSAttributedString.Key: AnyObject]
+	override internal func authorLabelAttributes() -> [NSAttributedString.Key: AnyObject]
 	{
 		return FocusedStatusTableCellView._authorLabelAttributes
 	}
 
-	internal override func statusLabelAttributes() -> [NSAttributedString.Key: AnyObject]
+	override internal func statusLabelAttributes() -> [NSAttributedString.Key: AnyObject]
 	{
 		return FocusedStatusTableCellView._statusLabelAttributes
 	}
 
-	internal override func statusLabelLinkAttributes() -> [NSAttributedString.Key: AnyObject]
+	override internal func statusLabelLinkAttributes() -> [NSAttributedString.Key: AnyObject]
 	{
 		return FocusedStatusTableCellView._statusLabelLinkAttributes
 	}
@@ -95,7 +95,8 @@ class FocusedStatusTableCellView: StatusTableCellView
 
 	@IBAction func showStatusApp(_ sender: Any?)
 	{
-		guard let applicationWebsite = sourceApplication?.website, let url = URL(string: applicationWebsite) else
+		guard let applicationWebsite = sourceApplication?.website, let url = URL(string: applicationWebsite)
+		else
 		{
 			return
 		}

--- a/Mastonaut/Views/Table Cell Views/FocusedStatusTableCellView.swift
+++ b/Mastonaut/Views/Table Cell Views/FocusedStatusTableCellView.swift
@@ -29,14 +29,14 @@ class FocusedStatusTableCellView: StatusTableCellView
 	override func awakeFromNib()
 	{
 		super.awakeFromNib()
-		
+
 		fontObserver = MastonautPreferences.instance.observe(\.focusedStatusFont, options: .new)
 		{
 			[weak self] _, _ in
 			self?.updateFont()
 		}
 	}
-	
+
 	private var fontObserver: NSKeyValueObservation?
 
 	deinit
@@ -46,6 +46,7 @@ class FocusedStatusTableCellView: StatusTableCellView
 
 	override func updateFont()
 	{
+		statusLabel.linkTextAttributes = statusLabelLinkAttributes()
 
 		redraw()
 	}
@@ -54,18 +55,6 @@ class FocusedStatusTableCellView: StatusTableCellView
 
 	private static let _authorLabelAttributes: [NSAttributedString.Key: AnyObject] = [
 		.foregroundColor: NSColor.labelColor, .font: NSFont.systemFont(ofSize: 15, weight: .semibold)
-	]
-
-//	private static let _statusLabelAttributes: [NSAttributedString.Key: AnyObject] = [
-//		.foregroundColor: NSColor.labelColor, .font: NSFont.labelFont(ofSize: 16),
-//		.underlineStyle: NSNumber(value: 0) // <-- This is a hack to prevent the label's contents from shifting
-//		// vertically when clicked.
-//	]
-
-	private static let _statusLabelLinkAttributes: [NSAttributedString.Key: AnyObject] = [
-		.foregroundColor: NSColor.safeControlTintColor,
-		.font: NSFont.systemFont(ofSize: 16, weight: .medium),
-		.underlineStyle: NSNumber(value: 1)
 	]
 
 	override internal func authorLabelAttributes() -> [NSAttributedString.Key: AnyObject]
@@ -85,7 +74,11 @@ class FocusedStatusTableCellView: StatusTableCellView
 
 	override internal func statusLabelLinkAttributes() -> [NSAttributedString.Key: AnyObject]
 	{
-		return FocusedStatusTableCellView._statusLabelLinkAttributes
+		return [
+			.foregroundColor: NSColor.safeControlTintColor,
+			.font: MastonautPreferences.instance.focusedStatusFont.withWeight(weight: .medium)!,
+			.underlineStyle: NSNumber(value: 1)
+		]
 	}
 
 	override func set(displayedStatus status: Status,

--- a/Mastonaut/Views/Table Cell Views/FocusedStatusTableCellView.swift
+++ b/Mastonaut/Views/Table Cell Views/FocusedStatusTableCellView.swift
@@ -17,6 +17,7 @@
 //  GNU General Public License for more details.
 //
 
+import CoreTootin
 import Foundation
 import MastodonKit
 
@@ -25,7 +26,26 @@ class FocusedStatusTableCellView: StatusTableCellView
 	@IBOutlet private unowned var appNameConatiner: NSView!
 	@IBOutlet private unowned var appNameLabel: NSButton!
 
-	private var sourceApplication: Application? = nil
+	override func awakeFromNib()
+	{
+		super.awakeFromNib()
+
+		MastonautPreferences.instance.addObserver(self, forKeyPath: "threadFontSize")
+	}
+
+	override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?)
+	{
+		switch keyPath
+		{
+		case "threadFontSize":
+//			statusLabel.font = MastonautPreferences.instance.timelineFont
+			break
+		default:
+			break
+		}
+	}
+
+	private var sourceApplication: Application?
 
 	private static let _authorLabelAttributes: [NSAttributedString.Key: AnyObject] = [
 		.foregroundColor: NSColor.labelColor, .font: NSFont.systemFont(ofSize: 15, weight: .semibold)
@@ -59,16 +79,16 @@ class FocusedStatusTableCellView: StatusTableCellView
 	}
 
 	override func set(displayedStatus status: Status,
-					  poll: Poll?,
-					  attachmentPresenter: AttachmentPresenting,
-					  interactionHandler: StatusInteractionHandling,
-					  activeInstance: Instance)
+	                  poll: Poll?,
+	                  attachmentPresenter: AttachmentPresenting,
+	                  interactionHandler: StatusInteractionHandling,
+	                  activeInstance: Instance)
 	{
 		super.set(displayedStatus: status,
-				  poll: poll,
-				  attachmentPresenter: attachmentPresenter,
-				  interactionHandler: interactionHandler,
-				  activeInstance: activeInstance)
+		          poll: poll,
+		          attachmentPresenter: attachmentPresenter,
+		          interactionHandler: interactionHandler,
+		          activeInstance: activeInstance)
 
 		setContentLabelsSelectable(true)
 

--- a/Mastonaut/Views/Table Cell Views/FocusedStatusTableCellView.swift
+++ b/Mastonaut/Views/Table Cell Views/FocusedStatusTableCellView.swift
@@ -30,16 +30,17 @@ class FocusedStatusTableCellView: StatusTableCellView
 	{
 		super.awakeFromNib()
 
-		MastonautPreferences.instance.addObserver(self, forKeyPath: "threadFontSize")
+		MastonautPreferences.instance.addObserver(self, forKeyPath: MastonautPreferences.focusedFontFamilyKey)
+		MastonautPreferences.instance.addObserver(self, forKeyPath: MastonautPreferences.focusedFontSizeKey)
 	}
 
 	override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?)
 	{
 		switch keyPath
 		{
-		case "threadFontSize":
-//			statusLabel.font = MastonautPreferences.instance.timelineFont
-			break
+		case MastonautPreferences.focusedFontFamilyKey,
+		     MastonautPreferences.focusedFontSizeKey:
+			redraw()
 		default:
 			break
 		}
@@ -51,11 +52,11 @@ class FocusedStatusTableCellView: StatusTableCellView
 		.foregroundColor: NSColor.labelColor, .font: NSFont.systemFont(ofSize: 15, weight: .semibold)
 	]
 
-	private static let _statusLabelAttributes: [NSAttributedString.Key: AnyObject] = [
-		.foregroundColor: NSColor.labelColor, .font: NSFont.labelFont(ofSize: 16),
-		.underlineStyle: NSNumber(value: 0) // <-- This is a hack to prevent the label's contents from shifting
-		// vertically when clicked.
-	]
+//	private static let _statusLabelAttributes: [NSAttributedString.Key: AnyObject] = [
+//		.foregroundColor: NSColor.labelColor, .font: NSFont.labelFont(ofSize: 16),
+//		.underlineStyle: NSNumber(value: 0) // <-- This is a hack to prevent the label's contents from shifting
+//		// vertically when clicked.
+//	]
 
 	private static let _statusLabelLinkAttributes: [NSAttributedString.Key: AnyObject] = [
 		.foregroundColor: NSColor.safeControlTintColor,
@@ -70,7 +71,12 @@ class FocusedStatusTableCellView: StatusTableCellView
 
 	override internal func statusLabelAttributes() -> [NSAttributedString.Key: AnyObject]
 	{
-		return FocusedStatusTableCellView._statusLabelAttributes
+		return [
+			.foregroundColor: NSColor.labelColor,
+			.font: MastonautPreferences.instance.focusedFont,
+			.underlineStyle: NSNumber(value: 0) // <-- This is a hack to prevent the label's contents from shifting
+			// vertically when clicked.
+		]
 	}
 
 	override internal func statusLabelLinkAttributes() -> [NSAttributedString.Key: AnyObject]

--- a/Mastonaut/Views/Table Cell Views/FocusedStatusTableCellView.swift
+++ b/Mastonaut/Views/Table Cell Views/FocusedStatusTableCellView.swift
@@ -26,6 +26,11 @@ class FocusedStatusTableCellView: StatusTableCellView
 	@IBOutlet private unowned var appNameConatiner: NSView!
 	@IBOutlet private unowned var appNameLabel: NSButton!
 
+	private func fontService() -> FontService
+	{
+		return FontService(font: MastonautPreferences.instance.focusedStatusFont)
+	}
+
 	override func awakeFromNib()
 	{
 		super.awakeFromNib()
@@ -55,29 +60,17 @@ class FocusedStatusTableCellView: StatusTableCellView
 
 	override internal func authorLabelAttributes() -> [NSAttributedString.Key: AnyObject]
 	{
-		return [
-			.foregroundColor: NSColor.labelColor,
-			.font: MastonautPreferences.instance.focusedStatusFont.withWeight(weight: .semibold)!
-		]
+		return fontService().authorAttributes()
 	}
 
 	override internal func statusLabelAttributes() -> [NSAttributedString.Key: AnyObject]
 	{
-		return [
-			.foregroundColor: NSColor.labelColor,
-			.font: MastonautPreferences.instance.focusedStatusFont,
-			.underlineStyle: NSNumber(value: 0) // <-- This is a hack to prevent the label's contents from shifting
-			// vertically when clicked.
-		]
+		return fontService().statusAttributes()
 	}
 
 	override internal func statusLabelLinkAttributes() -> [NSAttributedString.Key: AnyObject]
 	{
-		return [
-			.foregroundColor: NSColor.safeControlTintColor,
-			.font: MastonautPreferences.instance.focusedStatusFont.withWeight(weight: .medium)!,
-			.underlineStyle: NSNumber(value: 1)
-		]
+		return fontService().statusLinkAttributes()
 	}
 
 	override func set(displayedStatus status: Status,

--- a/Mastonaut/Views/Table Cell Views/FocusedStatusTableCellView.swift
+++ b/Mastonaut/Views/Table Cell Views/FocusedStatusTableCellView.swift
@@ -53,13 +53,12 @@ class FocusedStatusTableCellView: StatusTableCellView
 
 	private var sourceApplication: Application?
 
-	private static let _authorLabelAttributes: [NSAttributedString.Key: AnyObject] = [
-		.foregroundColor: NSColor.labelColor, .font: NSFont.systemFont(ofSize: 15, weight: .semibold)
-	]
-
 	override internal func authorLabelAttributes() -> [NSAttributedString.Key: AnyObject]
 	{
-		return FocusedStatusTableCellView._authorLabelAttributes
+		return [
+			.foregroundColor: NSColor.labelColor,
+			.font: MastonautPreferences.instance.focusedStatusFont.withWeight(weight: .semibold)!
+		]
 	}
 
 	override internal func statusLabelAttributes() -> [NSAttributedString.Key: AnyObject]

--- a/Mastonaut/Views/Table Cell Views/FollowCellView.swift
+++ b/Mastonaut/Views/Table Cell Views/FollowCellView.swift
@@ -39,28 +39,16 @@ class FollowCellView: MastonautTableCellView, NotificationDisplaying
 
 	// This cell never displays statuses
 	let displayedStatusId: String? = nil
-
-	private static let followLabelAttributes: [NSAttributedString.Key: AnyObject] = [
-		.foregroundColor: NSColor.labelColor, .font: NSFont.systemFont(ofSize: 14, weight: .medium)
-	]
-
-	private static let userBioLabelAttributes: [NSAttributedString.Key: AnyObject] = [
-		.foregroundColor: NSColor.labelColor, .font: NSFont.labelFont(ofSize: 13),
-		.underlineStyle: NSNumber(value: 0) // <-- This is a hack to prevent the label's contents from shifting
-											// vertically when clicked.
-	]
-
-	private static let bioLabelLinkAttributes: [NSAttributedString.Key: AnyObject] = [
-		.foregroundColor: NSColor.safeControlTintColor,
-		.font: NSFont.systemFont(ofSize: 13, weight: .medium),
-		.underlineStyle: NSNumber(value: 1)
-	]
+	
+	private func fontService() -> FontService {
+		return FontService(font: MastonautPreferences.instance.statusFont)
+	}
 
 	override func awakeFromNib() {
 		super.awakeFromNib()
 
 		timeLabel.formatter = RelativeDateFormatter.shared
-		userBioLabel.linkTextAttributes = FollowCellView.bioLabelLinkAttributes
+		userBioLabel.linkTextAttributes = fontService().userBioLinkAttributes()
 	}
 
 	override var backgroundStyle: NSView.BackgroundStyle
@@ -94,11 +82,11 @@ class FollowCellView: MastonautTableCellView, NotificationDisplaying
 		userBioLabel.linkHandler = self
 
 		interactionLabel.set(stringValue: 🔠("%@ followed you", notification.authorName),
-							 applyingAttributes: FollowCellView.followLabelAttributes,
+							 applyingAttributes: fontService().followAttributes(),
 							 applyingEmojis: accountEmojis)
 
 		userBioLabel.set(attributedStringValue: notification.account.attributedNote,
-						 applyingAttributes: FollowCellView.userBioLabelAttributes,
+						 applyingAttributes: fontService().userBioAttributes(),
 						 applyingEmojis: accountEmojis)
 
 		userBioLabel.isHidden = userBioLabel.attributedStringValue.length == 0

--- a/Mastonaut/Views/Table Cell Views/InteractionCellView.swift
+++ b/Mastonaut/Views/Table Cell Views/InteractionCellView.swift
@@ -18,8 +18,8 @@
 //
 
 import Cocoa
-import MastodonKit
 import CoreTootin
+import MastodonKit
 
 class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 {
@@ -40,38 +40,62 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 	@IBOutlet private unowned var reblogButton: NSButton!
 	@IBOutlet private unowned var favoriteButton: NSButton!
 	@IBOutlet private unowned var timeLabel: NSTextField!
-	
-	private func fontService() -> FontService {
+
+	private func fontService() -> FontService
+	{
 		return FontService(font: MastonautPreferences.instance.statusFont)
 	}
 
-	var displayedNotificationId: String? = nil
+	var displayedNotificationId: String?
 
-	private var displayedNotificationType: NotificationType? = nil
-	private var displayedNotificationTags: [Tag]? = nil
-	private var authorAccount: Account? = nil
-	private var agentAccount: Account? = nil
+	private var displayedNotificationType: NotificationType?
+	private var displayedNotificationTags: [Tag]?
+	private var authorAccount: Account?
+	private var agentAccount: Account?
+
+	private var notification: MastodonNotification?
+	private var activeInstance: Instance?
 
 	private var pollViewController: PollViewController?
 
 	/// Notifications can be relative to a status, so we de technically have to comply with StatusDisplaying
-	var displayedStatusId: String? = nil
+	var displayedStatusId: String?
 
-	private unowned var interactionHandler: NotificationInteractionHandling? = nil
+	private unowned var interactionHandler: NotificationInteractionHandling?
 
 	override func awakeFromNib()
 	{
 		super.awakeFromNib()
 
 		timeLabel.formatter = RelativeDateFormatter.shared
-		statusLabel.linkTextAttributes = fontService().statusLinkAttributes()
+
+		fontObserver = MastonautPreferences.instance.observe(\.statusFont, options: .new)
+		{
+			[weak self] _, _ in
+			self?.updateFont()
+		}
 	}
-	
+
+	private var fontObserver: NSKeyValueObservation?
+
+	deinit
+	{
+		fontObserver?.invalidate()
+	}
+
+	func updateFont()
+	{
+		statusLabel.linkTextAttributes = fontService().statusLinkAttributes()
+
+		redraw()
+	}
+
 	override var backgroundStyle: NSView.BackgroundStyle
 	{
 		didSet
 		{
-			guard let notificationType = displayedNotificationType else
+			guard let notificationType = displayedNotificationType
+			else
 			{
 				return
 			}
@@ -83,7 +107,7 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 			{
 			case .reblog:
 				interactionIcon.image = emphasized ? #imageLiteral(resourceName: "retooted") : #imageLiteral(resourceName: "retooted_active")
-				
+
 			case .favourite:
 				interactionIcon.image = emphasized ? #imageLiteral(resourceName: "favorited") : #imageLiteral(resourceName: "favorited_active")
 
@@ -93,7 +117,7 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 			case .follow:
 				// This type of notification is handled by a different notification cell view.
 				break
-				
+
 			case .mention:
 				// This type of notification is handled by adapting a status cell view.
 				break
@@ -102,11 +126,11 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 				// This should have been catch beforereaching the UI level.
 				break
 			}
-			
+
 			if #available(OSX 10.14, *) {} else
 			{
 				statusLabel.isEmphasized = emphasized
-				
+
 				let effectiveColor: NSColor = emphasized ? .alternateSelectedControlTextColor : .secondaryLabelColor
 				authorAccountLabel.textColor = effectiveColor
 				timeLabel.textColor = effectiveColor
@@ -116,10 +140,12 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 	}
 
 	func set(displayedNotification notification: MastodonNotification,
-			 attachmentPresenter: AttachmentPresenting,
-			 interactionHandler: NotificationInteractionHandling,
-			 activeInstance: Instance)
+	         attachmentPresenter: AttachmentPresenting,
+	         interactionHandler: NotificationInteractionHandling,
+	         activeInstance: Instance)
 	{
+		self.notification = notification
+
 		displayedNotificationId = notification.id
 		displayedNotificationType = notification.type
 		displayedStatusId = notification.status?.id
@@ -132,6 +158,15 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 
 		authorAccount = notification.status?.account
 		agentAccount = notification.account
+
+		self.activeInstance = activeInstance
+
+		redraw()
+	}
+
+	func redraw()
+	{
+		guard let notification, let activeInstance else { return }
 
 		let interactionMessage: String
 		let status = notification.status
@@ -171,15 +206,17 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 		}
 
 		interactionLabel.set(stringValue: interactionMessage,
-							 applyingAttributes: messageAttributes,
-							 applyingEmojis: notification.account.cacheableEmojis)
+		                     applyingAttributes: messageAttributes,
+		                     applyingEmojis: notification.account.cacheableEmojis)
 
 		authorAvatarButton.image = #imageLiteral(resourceName: "missing")
 		agentAvatarButton.image = #imageLiteral(resourceName: "missing")
 
 		let localNotificationID = notification.id
-		AppDelegate.shared.avatarImageCache.fetchImage(account: notification.account) { [weak self] result in
-			switch result {
+		AppDelegate.shared.avatarImageCache.fetchImage(account: notification.account)
+		{ [weak self] result in
+			switch result
+			{
 			case .inCache(let avatarImage):
 				assert(Thread.isMainThread)
 				self?.agentAvatarButton.image = avatarImage
@@ -190,9 +227,12 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 			}
 		}
 
-		if let account = notification.status?.account {
-			AppDelegate.shared.avatarImageCache.fetchImage(account: account) { [weak self] result in
-				switch result {
+		if let account = notification.status?.account
+		{
+			AppDelegate.shared.avatarImageCache.fetchImage(account: account)
+			{ [weak self] result in
+				switch result
+				{
 				case .inCache(let avatarImage):
 					assert(Thread.isMainThread)
 					self?.authorAvatarButton.image = avatarImage
@@ -212,9 +252,11 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 
 	private func applyAgentImageIfNotReused(_ image: NSImage?, originatingNotificationID: String)
 	{
-		DispatchQueue.main.async { [weak self] in
+		DispatchQueue.main.async
+		{ [weak self] in
 			// Make sure that the notification view hasn't been reused since this fetch was dispatched.
-			guard self?.displayedNotificationId == originatingNotificationID else
+			guard self?.displayedNotificationId == originatingNotificationID
+			else
 			{
 				return
 			}
@@ -225,9 +267,11 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 
 	private func applyAuthorImageIfNotReused(_ image: NSImage?, originatingNotificationID: String)
 	{
-		DispatchQueue.main.async { [weak self] in
+		DispatchQueue.main.async
+		{ [weak self] in
 			// Make sure that the notification view hasn't been reused since this fetch was dispatched.
-			guard self?.displayedNotificationId == originatingNotificationID else
+			guard self?.displayedNotificationId == originatingNotificationID
+			else
 			{
 				return
 			}
@@ -243,7 +287,7 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 			attachmentInfoStackView.isHidden = false
 			attachmentIcon.image = #imageLiteral(resourceName: "attachment")
 			attachmentInfoLabel.stringValue = attachmentCount == 1 ? 🔠("one attachment")
-																   : 🔠("%@ attachments", String(attachmentCount))
+				: 🔠("%@ attachments", String(attachmentCount))
 		}
 		else
 		{
@@ -254,8 +298,8 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 	private func set(authorName: String, account: String, emojis: [CacheableEmoji])
 	{
 		authorNameLabel.set(stringValue: authorName,
-							applyingAttributes: fontService().authorAttributes(),
-							applyingEmojis: emojis)
+		                    applyingAttributes: fontService().authorAttributes(),
+		                    applyingEmojis: emojis)
 
 		authorAccountLabel.stringValue = account
 	}
@@ -268,7 +312,8 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 
 	private func set(status: Status?, activeInstance: Instance)
 	{
-		guard let status = status else
+		guard let status = status
+		else
 		{
 			statusLabel.isHidden = true
 			set(attachmentCount: 0)
@@ -283,31 +328,34 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 		{
 			contentWarningContainerView.isHidden = false
 			contentWarningLabel.set(attributedStringValue: status.attributedSpoiler,
-									applyingAttributes: fontService().statusAttributes(),
-									applyingEmojis: status.cacheableEmojis)
+			                        applyingAttributes: fontService().statusAttributes(),
+			                        applyingEmojis: status.cacheableEmojis)
 		}
 
 		let attributedStatusContent = status.fullAttributedContent
 
-		if attributedStatusContent.isEmpty {
+		if attributedStatusContent.isEmpty
+		{
 			statusLabel.isHidden = true
-		} else {
+		}
+		else
+		{
 			statusLabel.isHidden = false
 			statusLabel.set(attributedStringValue: attributedStatusContent,
-							applyingAttributes: fontService().statusAttributes(),
-							applyingEmojis: status.cacheableEmojis)
+			                applyingAttributes: fontService().statusAttributes(),
+			                applyingEmojis: status.cacheableEmojis)
 		}
 
 		reblogButton.isEnabled = status.visibility.allowsReblog
 		reblogButton.toolTip = status.visibility.reblogToolTip(didReblog: status.reblogged == true)
 		reblogButton.image = status.visibility.reblogIcon
 
-		reblogButton.state		= status.reblogged == true ? .on : .off
-		favoriteButton.state	= status.favourited == true ? .on : .off
+		reblogButton.state = status.reblogged == true ? .on : .off
+		favoriteButton.state = status.favourited == true ? .on : .off
 
 		set(authorName: status.authorName,
-			account: status.account.uri(in: activeInstance),
-			emojis: status.account.cacheableEmojis)
+		    account: status.account.uri(in: activeInstance),
+		    emojis: status.account.cacheableEmojis)
 
 		set(attachmentCount: status.mediaAttachments.count)
 		set(creationTime: status.createdAt)
@@ -328,7 +376,6 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 	{
 		pollViewController?.set(poll: updatedPoll)
 	}
-
 
 	override func prepareForReuse()
 	{
@@ -351,7 +398,8 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 
 	@IBAction private func interactionButtonClicked(_ sender: NSButton)
 	{
-		guard let interactedNotificationId = displayedNotificationId else
+		guard let interactedNotificationId = displayedNotificationId
+		else
 		{
 			return
 		}
@@ -364,10 +412,10 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 				[weak self] success in
 
 				DispatchQueue.main.async
-					{
-						guard self?.displayedNotificationId == interactedNotificationId else { return }
-						self?.favoriteButton.state = success ? .on : .off
-					}
+				{
+					guard self?.displayedNotificationId == interactedNotificationId else { return }
+					self?.favoriteButton.state = success ? .on : .off
+				}
 			}
 
 		case (favoriteButton, .off):
@@ -376,10 +424,10 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 				[weak self] success in
 
 				DispatchQueue.main.async
-					{
-						guard self?.displayedNotificationId == interactedNotificationId else { return }
-						self?.favoriteButton.state = success ? .off : .on
-					}
+				{
+					guard self?.displayedNotificationId == interactedNotificationId else { return }
+					self?.favoriteButton.state = success ? .off : .on
+				}
 			}
 
 		case (reblogButton, .on):
@@ -388,10 +436,10 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 				[weak self] success in
 
 				DispatchQueue.main.async
-					{
-						guard self?.displayedNotificationId == interactedNotificationId else { return }
-						self?.reblogButton.state = success ? .on : .off
-					}
+				{
+					guard self?.displayedNotificationId == interactedNotificationId else { return }
+					self?.reblogButton.state = success ? .on : .off
+				}
 			}
 
 		case (reblogButton, .off):
@@ -400,14 +448,15 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 				[weak self] success in
 
 				DispatchQueue.main.async
-					{
-						guard self?.displayedNotificationId == interactedNotificationId else { return }
-						self?.reblogButton.state = success ? .off : .on
-					}
+				{
+					guard self?.displayedNotificationId == interactedNotificationId else { return }
+					self?.reblogButton.state = success ? .off : .on
+				}
 			}
 
 		case (replyButton, _):
-			guard let statusID = displayedStatusId else
+			guard let statusID = displayedStatusId
+			else
 			{
 				return
 			}
@@ -437,9 +486,9 @@ extension InteractionCellView: RichTextCapable
 {
 	func set(shouldDisplayAnimatedContents animates: Bool)
 	{
-		interactionLabel.animatedEmojiImageViews?.forEach({ $0.animates = animates })
-		authorNameLabel.animatedEmojiImageViews?.forEach({ $0.animates = animates })
-		statusLabel.animatedEmojiImageViews?.forEach({ $0.animates = animates })
-		contentWarningLabel.animatedEmojiImageViews?.forEach({ $0.animates = animates })
+		interactionLabel.animatedEmojiImageViews?.forEach { $0.animates = animates }
+		authorNameLabel.animatedEmojiImageViews?.forEach { $0.animates = animates }
+		statusLabel.animatedEmojiImageViews?.forEach { $0.animates = animates }
+		contentWarningLabel.animatedEmojiImageViews?.forEach { $0.animates = animates }
 	}
 }

--- a/Mastonaut/Views/Table Cell Views/InteractionCellView.swift
+++ b/Mastonaut/Views/Table Cell Views/InteractionCellView.swift
@@ -40,6 +40,10 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 	@IBOutlet private unowned var reblogButton: NSButton!
 	@IBOutlet private unowned var favoriteButton: NSButton!
 	@IBOutlet private unowned var timeLabel: NSTextField!
+	
+	private func fontService() -> FontService {
+		return FontService(font: MastonautPreferences.instance.statusFont)
+	}
 
 	var displayedNotificationId: String? = nil
 
@@ -55,43 +59,12 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 
 	private unowned var interactionHandler: NotificationInteractionHandling? = nil
 
-	private static let reblogLabelAttributes: [NSAttributedString.Key: AnyObject] = [
-		.foregroundColor: NSColor.statusReblogged,
-		.font: NSFont.systemFont(ofSize: 14, weight: .medium)
-	]
-
-	private static let favoriteLabelAttributes: [NSAttributedString.Key: AnyObject] = [
-		.foregroundColor: NSColor.statusFavorited,
-		.font: NSFont.systemFont(ofSize: 14, weight: .medium)
-	]
-
-	private static let interactionLabelAttributes: [NSAttributedString.Key: AnyObject] = [
-		.foregroundColor: NSColor.labelColor,
-		.font: NSFont.systemFont(ofSize: 14, weight: .medium)
-	]
-
-	private static let authorLabelAttributes: [NSAttributedString.Key: AnyObject] = [
-		.foregroundColor: NSColor.labelColor,
-		.font: NSFont.systemFont(ofSize: 13, weight: .semibold)
-	]
-
-	private static let statusLabelAttributes: [NSAttributedString.Key: AnyObject] = [
-		.foregroundColor: NSColor.labelColor,
-		.font: NSFont.labelFont(ofSize: 13)
-	]
-
-	private static let statusLabelLinkAttributes: [NSAttributedString.Key: AnyObject] = [
-		.foregroundColor: NSColor.safeControlTintColor,
-		.font: NSFont.systemFont(ofSize: 13, weight: .medium),
-		.underlineStyle: NSNumber(value: 1)
-	]
-
 	override func awakeFromNib()
 	{
 		super.awakeFromNib()
 
 		timeLabel.formatter = RelativeDateFormatter.shared
-		statusLabel.linkTextAttributes = InteractionCellView.statusLabelLinkAttributes
+		statusLabel.linkTextAttributes = fontService().statusLinkAttributes()
 	}
 	
 	override var backgroundStyle: NSView.BackgroundStyle
@@ -169,19 +142,19 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 		case .reblog:
 			interactionIcon.image = #imageLiteral(resourceName: "retooted_active")
 			interactionMessage = 🔠("%@ boosted", notification.authorName)
-			messageAttributes = InteractionCellView.reblogLabelAttributes
+			messageAttributes = fontService().reblogAttributes()
 			set(status: status, activeInstance: activeInstance)
 
 		case .favourite:
 			interactionIcon.image = #imageLiteral(resourceName: "favorited_active")
 			interactionMessage = 🔠("%@ favorited", notification.authorName)
-			messageAttributes = InteractionCellView.favoriteLabelAttributes
+			messageAttributes = fontService().favoriteAttributes()
 			set(status: status, activeInstance: activeInstance)
 
 		case .poll:
 			interactionIcon.image = #imageLiteral(resourceName: "poll")
 			interactionMessage = 🔠("A poll has ended")
-			messageAttributes = InteractionCellView.interactionLabelAttributes
+			messageAttributes = fontService().interactionAttributes()
 			set(status: status, activeInstance: activeInstance)
 
 		case .follow:
@@ -281,7 +254,7 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 	private func set(authorName: String, account: String, emojis: [CacheableEmoji])
 	{
 		authorNameLabel.set(stringValue: authorName,
-							applyingAttributes: InteractionCellView.authorLabelAttributes,
+							applyingAttributes: fontService().authorAttributes(),
 							applyingEmojis: emojis)
 
 		authorAccountLabel.stringValue = account
@@ -310,7 +283,7 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 		{
 			contentWarningContainerView.isHidden = false
 			contentWarningLabel.set(attributedStringValue: status.attributedSpoiler,
-									applyingAttributes: InteractionCellView.statusLabelAttributes,
+									applyingAttributes: fontService().statusAttributes(),
 									applyingEmojis: status.cacheableEmojis)
 		}
 
@@ -321,7 +294,7 @@ class InteractionCellView: MastonautTableCellView, NotificationDisplaying
 		} else {
 			statusLabel.isHidden = false
 			statusLabel.set(attributedStringValue: attributedStatusContent,
-							applyingAttributes: InteractionCellView.statusLabelAttributes,
+							applyingAttributes: fontService().statusAttributes(),
 							applyingEmojis: status.cacheableEmojis)
 		}
 

--- a/Mastonaut/Views/Table Cell Views/StatusTableCellView.swift
+++ b/Mastonaut/Views/Table Cell Views/StatusTableCellView.swift
@@ -90,17 +90,16 @@ class StatusTableCellView: MastonautTableCellView, StatusDisplaying, StatusInter
 		return coverView
 	}()
 
-	private static let _authorLabelAttributes: [NSAttributedString.Key: AnyObject] = [
-		.foregroundColor: NSColor.labelColor, .font: NSFont.systemFont(ofSize: 14, weight: .semibold)
-	]
-
 	private static let _contextLabelAttributes: [NSAttributedString.Key: AnyObject] = [
 		.foregroundColor: NSColor.secondaryLabelColor, .font: NSFont.systemFont(ofSize: 12, weight: .medium)
 	]
 
 	internal func authorLabelAttributes() -> [NSAttributedString.Key: AnyObject]
 	{
-		return StatusTableCellView._authorLabelAttributes
+		return [
+			.foregroundColor: NSColor.labelColor,
+			.font: MastonautPreferences.instance.statusFont.withWeight(weight: .semibold)!
+		]
 	}
 
 	internal func statusLabelAttributes() -> [NSAttributedString.Key: AnyObject]

--- a/Mastonaut/Views/Table Cell Views/StatusTableCellView.swift
+++ b/Mastonaut/Views/Table Cell Views/StatusTableCellView.swift
@@ -119,7 +119,7 @@ class StatusTableCellView: MastonautTableCellView, StatusDisplaying, StatusInter
 	{
 		return [
 			.foregroundColor: NSColor.labelColor,
-			.font: MastonautPreferences.instance.timelineFont,
+			.font: MastonautPreferences.instance.statusFont,
 			.underlineStyle: NSNumber(value: 0) // <-- This is a hack to prevent the label's contents from shifting
 			// vertically when clicked.
 		]
@@ -144,16 +144,16 @@ class StatusTableCellView: MastonautTableCellView, StatusDisplaying, StatusInter
 
 		cardContainerView.clickHandler = { [weak self] in self?.cellModel?.openCardLink() }
 
-		MastonautPreferences.instance.addObserver(self, forKeyPath: MastonautPreferences.timelineFontFamilyKey)
-		MastonautPreferences.instance.addObserver(self, forKeyPath: MastonautPreferences.timelineFontSizeKey)
+		MastonautPreferences.instance.addObserver(self, forKeyPath: MastonautPreferences.statusFontFamilyKey)
+		MastonautPreferences.instance.addObserver(self, forKeyPath: MastonautPreferences.statusFontSizeKey)
 	}
 
 	override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?)
 	{
 		switch keyPath
 		{
-		case MastonautPreferences.timelineFontFamilyKey,
-		     MastonautPreferences.timelineFontSizeKey:
+		case MastonautPreferences.statusFontFamilyKey,
+		     MastonautPreferences.statusFontSizeKey:
 			// focused views have different font sizes
 			if type(of: self) != FocusedStatusTableCellView.self
 			{

--- a/Mastonaut/Views/Table Cell Views/StatusTableCellView.swift
+++ b/Mastonaut/Views/Table Cell Views/StatusTableCellView.swift
@@ -144,24 +144,24 @@ class StatusTableCellView: MastonautTableCellView, StatusDisplaying, StatusInter
 
 		cardContainerView.clickHandler = { [weak self] in self?.cellModel?.openCardLink() }
 
-		MastonautPreferences.instance.addObserver(self, forKeyPath: MastonautPreferences.statusFontFamilyKey)
-		MastonautPreferences.instance.addObserver(self, forKeyPath: MastonautPreferences.statusFontSizeKey)
+		fontObserver = MastonautPreferences.instance.observe(\.statusFont, options: .new)
+		{
+			[weak self] _, _ in
+			self?.updateFont()
+		}
 	}
 
-	override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?)
+	private var fontObserver: NSKeyValueObservation?
+
+	deinit
 	{
-		switch keyPath
-		{
-		case MastonautPreferences.statusFontFamilyKey,
-		     MastonautPreferences.statusFontSizeKey:
-			// focused views have different font sizes
-			if type(of: self) != FocusedStatusTableCellView.self
-			{
-				redraw()
-			}
-		default:
-			break
-		}
+		fontObserver?.invalidate()
+	}
+
+	func updateFont()
+	{
+
+		redraw()
 	}
 
 	override var backgroundStyle: NSView.BackgroundStyle

--- a/Mastonaut/Views/Table Cell Views/StatusTableCellView.swift
+++ b/Mastonaut/Views/Table Cell Views/StatusTableCellView.swift
@@ -60,6 +60,10 @@ class StatusTableCellView: MastonautTableCellView, StatusDisplaying, StatusInter
 	private(set) var hasMedia: Bool = false
 	private(set) var hasSensitiveMedia: Bool = false
 	private(set) var hasSpoiler: Bool = false
+	
+	private func fontService() -> FontService {
+		return FontService(font: MastonautPreferences.instance.statusFont)
+	}
 
 	var isContentHidden: Bool
 	{
@@ -98,29 +102,17 @@ class StatusTableCellView: MastonautTableCellView, StatusDisplaying, StatusInter
 
 	internal func authorLabelAttributes() -> [NSAttributedString.Key: AnyObject]
 	{
-		return [
-			.foregroundColor: NSColor.labelColor,
-			.font: MastonautPreferences.instance.statusFont.withWeight(weight: .semibold)!
-		]
+		return fontService().authorAttributes()
 	}
 
 	internal func statusLabelAttributes() -> [NSAttributedString.Key: AnyObject]
 	{
-		return [
-			.foregroundColor: NSColor.labelColor,
-			.font: MastonautPreferences.instance.statusFont,
-			.underlineStyle: NSNumber(value: 0) // <-- This is a hack to prevent the label's contents from shifting
-			// vertically when clicked.
-		]
+		return fontService().statusAttributes()
 	}
 
 	internal func statusLabelLinkAttributes() -> [NSAttributedString.Key: AnyObject]
 	{
-		return [
-			.foregroundColor: NSColor.safeControlTintColor,
-			.font: MastonautPreferences.instance.statusFont.withWeight(weight: .medium)!,
-			.underlineStyle: NSNumber(value: 1)
-		]
+		return fontService().statusLinkAttributes()
 	}
 
 	internal func contextLabelAttributes() -> [NSAttributedString.Key: AnyObject]
@@ -206,7 +198,7 @@ class StatusTableCellView: MastonautTableCellView, StatusDisplaying, StatusInter
 		contentWarningLabel.linkHandler = cellModel
 
 		authorNameButton.set(stringValue: cellModel.visibleStatus.authorName,
-		                     applyingAttributes: authorLabelAttributes(),
+							 applyingAttributes: fontService().authorAttributes(),
 		                     applyingEmojis: cellModel.visibleStatus.account.cacheableEmojis)
 
 		contextButton.map { cellModel.setupContextButton($0, attributes: contextLabelAttributes()) }

--- a/Mastonaut/Views/Table Cell Views/StatusTableCellView.swift
+++ b/Mastonaut/Views/Table Cell Views/StatusTableCellView.swift
@@ -90,6 +90,8 @@ class StatusTableCellView: MastonautTableCellView, StatusDisplaying, StatusInter
 		return coverView
 	}()
 
+	// this is exempt from #83 (custom font) for now, because it's mostly UI
+	// chrome, not content
 	private static let _contextLabelAttributes: [NSAttributedString.Key: AnyObject] = [
 		.foregroundColor: NSColor.secondaryLabelColor, .font: NSFont.systemFont(ofSize: 12, weight: .medium)
 	]

--- a/Mastonaut/Views/Table Cell Views/StatusTableCellView.swift
+++ b/Mastonaut/Views/Table Cell Views/StatusTableCellView.swift
@@ -27,7 +27,7 @@ class StatusTableCellView: MastonautTableCellView, StatusDisplaying, StatusInter
 {
 	@IBOutlet private unowned var authorNameButton: NSButton!
 	@IBOutlet private unowned var authorAccountLabel: NSTextField!
-	@IBOutlet private unowned var statusLabel: AttributedLabel!
+	@IBOutlet unowned var statusLabel: AttributedLabel!
 	@IBOutlet private unowned var fullContentDisclosureView: NSView?
 	@IBOutlet private unowned var timeLabel: NSTextField!
 	@IBOutlet private unowned var editInfoContainer: NSStackView!
@@ -94,18 +94,6 @@ class StatusTableCellView: MastonautTableCellView, StatusDisplaying, StatusInter
 		.foregroundColor: NSColor.labelColor, .font: NSFont.systemFont(ofSize: 14, weight: .semibold)
 	]
 
-//	private static let _statusLabelAttributes: [NSAttributedString.Key: AnyObject] = [
-//		.foregroundColor: NSColor.labelColor, .font: NSFont.labelFont(ofSize: 14),
-//		.underlineStyle: NSNumber(value: 0) // <-- This is a hack to prevent the label's contents from shifting
-//		// vertically when clicked.
-//	]
-
-	private static let _statusLabelLinkAttributes: [NSAttributedString.Key: AnyObject] = [
-		.foregroundColor: NSColor.safeControlTintColor,
-		.font: NSFont.systemFont(ofSize: 14, weight: .medium),
-		.underlineStyle: NSNumber(value: 1)
-	]
-
 	private static let _contextLabelAttributes: [NSAttributedString.Key: AnyObject] = [
 		.foregroundColor: NSColor.secondaryLabelColor, .font: NSFont.systemFont(ofSize: 12, weight: .medium)
 	]
@@ -127,7 +115,11 @@ class StatusTableCellView: MastonautTableCellView, StatusDisplaying, StatusInter
 
 	internal func statusLabelLinkAttributes() -> [NSAttributedString.Key: AnyObject]
 	{
-		return StatusTableCellView._statusLabelLinkAttributes
+		return [
+			.foregroundColor: NSColor.safeControlTintColor,
+			.font: MastonautPreferences.instance.statusFont.withWeight(weight: .medium)!,
+			.underlineStyle: NSNumber(value: 1)
+		]
 	}
 
 	internal func contextLabelAttributes() -> [NSAttributedString.Key: AnyObject]
@@ -160,6 +152,7 @@ class StatusTableCellView: MastonautTableCellView, StatusDisplaying, StatusInter
 
 	func updateFont()
 	{
+		statusLabel.linkTextAttributes = statusLabelLinkAttributes()
 
 		redraw()
 	}

--- a/Mastonaut/Window Controllers/StatusComposerWindowController.swift
+++ b/Mastonaut/Window Controllers/StatusComposerWindowController.swift
@@ -88,19 +88,10 @@ class StatusComposerWindowController: NSWindowController, UserPopUpButtonDisplay
 
 	private lazy var userPopUpButtonController = UserPopUpButtonSubcontroller(display: self)
 
-	private static let authorLabelAttributes: [NSAttributedString.Key: AnyObject] = [
-		.foregroundColor: NSColor.labelColor, .font: NSFont.systemFont(ofSize: 13, weight: .semibold)
-	]
-
-	private static let statusLabelAttributes: [NSAttributedString.Key: AnyObject] = [
-		.foregroundColor: NSColor.labelColor, .font: NSFont.labelFont(ofSize: 13)
-	]
-
-	private static let statusLabelLinkAttributes: [NSAttributedString.Key: AnyObject] = [
-		.foregroundColor: NSColor.safeControlTintColor,
-		.font: NSFont.systemFont(ofSize: 13, weight: .medium),
-		.underlineStyle: NSNumber(value: 1)
-	]
+	private func fontService() -> FontService
+	{
+		return FontService(font: MastonautPreferences.instance.statusFont)
+	}
 
 	private lazy var fileDropFilteringOptions: [NSPasteboard.ReadingOptionKey: Any]? =
 	{
@@ -468,7 +459,7 @@ class StatusComposerWindowController: NSWindowController, UserPopUpButtonDisplay
 
 		window?.registerForDraggedTypes([.fileURL, .png])
 
-		replyStatusContentsLabel.linkTextAttributes = StatusComposerWindowController.statusLabelLinkAttributes
+		replyStatusContentsLabel.linkTextAttributes = fontService().statusLinkAttributes()
 		visibilitySegmentedControl.isHidden = true
 
 		collapseAllDrawers()
@@ -661,12 +652,12 @@ class StatusComposerWindowController: NSWindowController, UserPopUpButtonDisplay
 		}
 
 		replyStatusAuthorNameLabel.set(stringValue: replyStatus.authorName,
-		                               applyingAttributes: StatusComposerWindowController.authorLabelAttributes,
+		                               applyingAttributes: fontService().authorAttributes(),
 		                               applyingEmojis: replyStatus.account.cacheableEmojis)
 
 		replyStatusContentsLabel.linkHandler = self
 		replyStatusContentsLabel.set(attributedStringValue: replyStatus.attributedContent,
-		                             applyingAttributes: StatusComposerWindowController.statusLabelAttributes,
+		                             applyingAttributes: fontService().statusAttributes(),
 		                             applyingEmojis: replyStatus.cacheableEmojis)
 
 		replyStatusAvatarView.image = #imageLiteral(resourceName: "missing")


### PR DESCRIPTION
- [x] preference storage

- [x] preferences view

(I'm not too keen on the SF Symbol use from the library we're using here, but it's OK)

- [x] observe/apply font to timeline status cell
- [x] observe/apply font to conversation ("focused") status cell
- [x] if you first click one Aa button then the other, the font panel closes. (It's also generally not clear which one is selected, but to be fair, TextEdit behaves the same…)
- [x] our naming is wrong. The focused view is really only for the focused cell (purple background), not for all in the thread.

~- [x] the change doesn't get applied to all rows. probably need to invalidate them?~

- [x] `StatusResultTableCellView`
- [x] `StatusComposerWindowController` (when replying?)
- [x] `EditedStatusTableCellView`
- [x] `FollowCellView`
- [x] `InteractionCellView`

