### PR TITLE
Allow following hashtags

### DIFF
--- a/CoreTootin/Extensions/AuthorizedAccount+Helpers.swift
+++ b/CoreTootin/Extensions/AuthorizedAccount+Helpers.swift
@@ -168,4 +168,35 @@ public extension AuthorizedAccount
 		fetchRequest.predicate = NSPredicate(format: "account = %@ AND name = %@", self, name)
 		return try! managedObjectContext!.fetch(fetchRequest).first
 	}
+	
+	func hasFollowedTag(_ tagName: String, client: ClientType) -> Bool
+	{
+		return followedTag(with: tagName, client: client) != nil
+	}
+
+	func followTag(_ tagName: String, client: ClientType)
+	{
+//		guard !isDeleted, hasFollowedTag(tagName) == false else { return }
+//		let tag = FollowedTag(context: managedObjectContext!)
+//		tag.name = tagName
+//		addToFollowedTags(tag)
+	}
+
+	func unfollowTag(_ tagName: String, client: ClientType)
+	{
+//		guard !isDeleted, let tag = followedTag(with: tagName) else { return }
+//		removeFromFollowedTags(tag)
+	}
+
+	private func followedTag(with name: String, client: ClientType) -> FollowedTag?
+	{
+		return nil
+//		let fetchRequest: NSFetchRequest<FollowedTag> = FollowedTag.fetchRequest()
+//		fetchRequest.predicate = NSPredicate(format: "account = %@ AND name = %@", self, name)
+//		return try! managedObjectContext!.fetch(fetchRequest).first
+	}
+}
+
+struct FollowedTag {
+	
 }

--- a/CoreTootin/Extensions/AuthorizedAccount+Helpers.swift
+++ b/CoreTootin/Extensions/AuthorizedAccount+Helpers.swift
@@ -168,35 +168,23 @@ public extension AuthorizedAccount
 		fetchRequest.predicate = NSPredicate(format: "account = %@ AND name = %@", self, name)
 		return try! managedObjectContext!.fetch(fetchRequest).first
 	}
-	
-	func hasFollowedTag(_ tagName: String, client: ClientType) -> Bool
+
+	func hasFollowedTag(_ tagName: String, client: ClientType) async -> Bool
 	{
-		return followedTag(with: tagName, client: client) != nil
+		let followedTags = try? await client.run(Tags.followed())
+
+		let filtered = followedTags?.value.filter { $0.name == tagName }
+
+		return filtered?.count ?? 0 > 0
 	}
 
-	func followTag(_ tagName: String, client: ClientType)
+	func followTag(_ tagName: String, client: ClientType) async
 	{
-//		guard !isDeleted, hasFollowedTag(tagName) == false else { return }
-//		let tag = FollowedTag(context: managedObjectContext!)
-//		tag.name = tagName
-//		addToFollowedTags(tag)
+		_ = try? await client.run(Tags.follow(name: tagName))
 	}
 
-	func unfollowTag(_ tagName: String, client: ClientType)
+	func unfollowTag(_ tagName: String, client: ClientType) async
 	{
-//		guard !isDeleted, let tag = followedTag(with: tagName) else { return }
-//		removeFromFollowedTags(tag)
+		_ = try? await client.run(Tags.unfollow(name: tagName))
 	}
-
-	private func followedTag(with name: String, client: ClientType) -> FollowedTag?
-	{
-		return nil
-//		let fetchRequest: NSFetchRequest<FollowedTag> = FollowedTag.fetchRequest()
-//		fetchRequest.predicate = NSPredicate(format: "account = %@ AND name = %@", self, name)
-//		return try! managedObjectContext!.fetch(fetchRequest).first
-	}
-}
-
-struct FollowedTag {
-	
 }

--- a/CoreTootin/Services/TagFollowService.swift
+++ b/CoreTootin/Services/TagFollowService.swift
@@ -1,0 +1,53 @@
+//
+//  TagFollowService.swift
+//  CoreTootin
+//
+//  Created by Sören Kuklau on 01.05.23.
+//  Copyright © 2023 Bruno Philipe. All rights reserved.
+//
+
+import Foundation
+import MastodonKit
+
+/// This is very similar to `TagBookmarkService`. However, whereas
+/// bookmarking tags is entirely a client-side feature (there's no API, as of 4.1),
+/// stored in Core Data, and surfaced in the menu bar, _following_ a tag is
+/// entirely server-side, stored in the API, and surfaced in your timeline.
+public class TagFollowService
+{
+	private let account: AuthorizedAccount
+	private let client: ClientType
+
+	public init(account: AuthorizedAccount, client: ClientType)
+	{
+		self.account = account
+		self.client = client
+	}
+
+	public func isTagFollowed(_ tag: String) -> Bool
+	{
+		return account.hasFollowedTag(tag, client: client)
+	}
+
+	public func followTag(_ tag: String)
+	{
+		account.followTag(tag, client: client)
+	}
+
+	public func unfollowTag(_ tag: String)
+	{
+		account.unfollowTag(tag, client: client)
+	}
+
+	public func toggleFollowedState(for tag: String)
+	{
+		if account.hasFollowedTag(tag, client: client)
+		{
+			unfollowTag(tag)
+		}
+		else
+		{
+			followTag(tag)
+		}
+	}
+}

--- a/CoreTootin/Services/TagFollowService.swift
+++ b/CoreTootin/Services/TagFollowService.swift
@@ -24,30 +24,30 @@ public class TagFollowService
 		self.client = client
 	}
 
-	public func isTagFollowed(_ tag: String) -> Bool
+	public func isTagFollowed(_ tag: String) async -> Bool
 	{
-		return account.hasFollowedTag(tag, client: client)
+		return await account.hasFollowedTag(tag, client: client)
 	}
 
-	public func followTag(_ tag: String)
+	public func followTag(_ tag: String) async
 	{
-		account.followTag(tag, client: client)
+		await account.followTag(tag, client: client)
 	}
 
-	public func unfollowTag(_ tag: String)
+	public func unfollowTag(_ tag: String) async
 	{
-		account.unfollowTag(tag, client: client)
+		await account.unfollowTag(tag, client: client)
 	}
 
-	public func toggleFollowedState(for tag: String)
+	public func toggleFollowedState(for tag: String) async
 	{
-		if account.hasFollowedTag(tag, client: client)
+		if await account.hasFollowedTag(tag, client: client)
 		{
-			unfollowTag(tag)
+			await unfollowTag(tag)
 		}
 		else
 		{
-			followTag(tag)
+			await followTag(tag)
 		}
 	}
 }

--- a/Mastonaut.xcodeproj/project.pbxproj
+++ b/Mastonaut.xcodeproj/project.pbxproj
@@ -524,6 +524,7 @@
 		5F4DAAAE29FEEDE4009FA0AE /* NSFont+withWeight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4DAAAD29FEEDE4009FA0AE /* NSFont+withWeight.swift */; };
 		5F5338B32960B23200C1D9AE /* ReplaceCharactersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5338B22960B23200C1D9AE /* ReplaceCharactersTests.swift */; };
 		5F6F8F602A0033DF00FB3414 /* FontService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6F8F5F2A0033DF00FB3414 /* FontService.swift */; };
+		5F6F8F6A2A0051BF00FB3414 /* TagFollowService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6F8F692A0051BF00FB3414 /* TagFollowService.swift */; };
 		5F74B959294F5DD900DE1909 /* StatusPrivacyPreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F74B958294F5DD900DE1909 /* StatusPrivacyPreferencesView.swift */; };
 		5F74B95A294F5DD900DE1909 /* StatusPrivacyPreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F74B958294F5DD900DE1909 /* StatusPrivacyPreferencesView.swift */; };
 		5F8C133C2969F1D9007BE2D5 /* Sdifft in Frameworks */ = {isa = PBXBuildFile; productRef = 5F8C133B2969F1D9007BE2D5 /* Sdifft */; };
@@ -997,6 +998,7 @@
 		5F4DAAAD29FEEDE4009FA0AE /* NSFont+withWeight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSFont+withWeight.swift"; sourceTree = "<group>"; };
 		5F5338B22960B23200C1D9AE /* ReplaceCharactersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaceCharactersTests.swift; sourceTree = "<group>"; };
 		5F6F8F5F2A0033DF00FB3414 /* FontService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontService.swift; sourceTree = "<group>"; };
+		5F6F8F692A0051BF00FB3414 /* TagFollowService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagFollowService.swift; sourceTree = "<group>"; };
 		5F74B958294F5DD900DE1909 /* StatusPrivacyPreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusPrivacyPreferencesView.swift; sourceTree = "<group>"; };
 		5F8C1346296A0661007BE2D5 /* EditedStatusTableCellView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = EditedStatusTableCellView.xib; sourceTree = "<group>"; };
 		5F8C1348296A06E3007BE2D5 /* EditedStatusTableCellView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditedStatusTableCellView.swift; sourceTree = "<group>"; };
@@ -1423,6 +1425,7 @@
 				1530427422AE83E300489F31 /* PostingService.swift */,
 				1530427722AE8F4300489F31 /* ResolverService.swift */,
 				154E9FDB234564F300885966 /* TagBookmarkService.swift */,
+				5F6F8F692A0051BF00FB3414 /* TagFollowService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -2698,6 +2701,7 @@
 				15EE2B02232EA0CB00155E16 /* ImageRestrainer.swift in Sources */,
 				15EE2B10232EA3EF00155E16 /* BorderView.swift in Sources */,
 				15F9F307232EB8BE00931594 /* BaseComposerTextView.swift in Sources */,
+				5F6F8F6A2A0051BF00FB3414 /* TagFollowService.swift in Sources */,
 				154478AF232B03A0009C71D4 /* MastonautPersistentContainer.swift in Sources */,
 				5F3BC8B229D0B44000CEBD7F /* SparklineTableCellView.swift in Sources */,
 				1574DE1E233C030A00AB1036 /* NetworkError.swift in Sources */,

--- a/Mastonaut/Models/SidebarMode.swift
+++ b/Mastonaut/Models/SidebarMode.swift
@@ -107,8 +107,10 @@ enum SidebarMode: RawRepresentable, SidebarModel, Equatable
 			return ProfileViewController(account: account, instance: currentInstance)
 
 		case .tag(let tag):
-			let service = currentAccount.map { TagBookmarkService(account: $0) }
-			return TagViewController(tag: tag, tagBookmarkService: service)
+			let bookmarkService = currentAccount.map { TagBookmarkService(account: $0) }
+			let followService = currentAccount.map { TagFollowService(account: $0, client: client) }
+			
+			return TagViewController(tag: tag, tagBookmarkService: bookmarkService, tagFollowService: followService)
 
 		case .status(let uri, nil):
 			return StatusThreadViewController(uri: uri, client: client)

--- a/Mastonaut/View Controllers/Sidebar/TagViewController.swift
+++ b/Mastonaut/View Controllers/Sidebar/TagViewController.swift
@@ -95,10 +95,17 @@ private class TagButtonsStateBindable: SidebarTitleButtonsStateBindable
 
 	private func updateFollowButton()
 	{
-		let isFollowed = tagFollowService.isTagFollowed(tag)
-		secondAccessibilityLabel = isFollowed ? 🔠("Unfollow Tag on Timeline") : 🔠("Follow Tag on Timeline")
-		secondIcon = NSImage(systemSymbolName: isFollowed ? "text.badge.xmark" : "text.badge.checkmark",
-		                     accessibilityDescription: secondAccessibilityLabel)
+		Task
+		{
+			let isFollowed = await tagFollowService.isTagFollowed(tag)
+
+			await MainActor.run
+			{
+				secondAccessibilityLabel = isFollowed ? 🔠("Unfollow Tag on Timeline") : 🔠("Follow Tag on Timeline")
+				secondIcon = NSImage(systemSymbolName: isFollowed ? "rectangle.fill.badge.xmark": "rectangle",
+				                     accessibilityDescription: secondAccessibilityLabel)
+			}
+		}
 	}
 
 	override func didClickFirstButton(_ sender: Any?)
@@ -109,7 +116,11 @@ private class TagButtonsStateBindable: SidebarTitleButtonsStateBindable
 
 	override func didClickSecondButton(_ sender: Any?)
 	{
-		tagFollowService.toggleFollowedState(for: tag)
-		updateFollowButton()
+		Task
+		{
+			await tagFollowService.toggleFollowedState(for: tag)
+
+			updateFollowButton()
+		}
 	}
 }

--- a/Mastonaut/View Controllers/TimelinesViewController.swift
+++ b/Mastonaut/View Controllers/TimelinesViewController.swift
@@ -303,7 +303,7 @@ indirect enum SidebarTitleMode
 	case none
 	case title(NSAttributedString)
 	case subtitle(title: NSAttributedString, subtitle: NSAttributedString)
-	case button(SidebarTitleButtonStateBindable, SidebarTitleMode)
+	case buttons(SidebarTitleButtonsStateBindable, SidebarTitleMode)
 
 	static func title(_ string: String) -> SidebarTitleMode
 	{
@@ -316,13 +316,24 @@ indirect enum SidebarTitleMode
 	}
 }
 
-@objc class SidebarTitleButtonStateBindable: NSObject
+@objc class SidebarTitleButtonsStateBindable: NSObject
 {
-	@objc dynamic var icon: NSImage? = nil
-	@objc dynamic var accessibilityLabel: String? = nil
-	@objc dynamic var accessibilityTitle: String? = nil
+	// this is currently hardcoded to two buttons,
+	// as we only use it for hashtags
+	
+	@objc dynamic var firstIcon: NSImage? = nil
+	@objc dynamic var firstAccessibilityLabel: String? = nil
+	@objc dynamic var firstAccessibilityTitle: String? = nil
 
-	@objc func didClickButton(_ sender: Any?)
+	@objc func didClickFirstButton(_ sender: Any?)
+	{
+	}
+	
+	@objc dynamic var secondIcon: NSImage? = nil
+	@objc dynamic var secondAccessibilityLabel: String? = nil
+	@objc dynamic var secondAccessibilityTitle: String? = nil
+
+	@objc func didClickSecondButton(_ sender: Any?)
 	{
 	}
 }

--- a/Mastonaut/Views/Sidebar Title Views/SidebarTitleViewController.swift
+++ b/Mastonaut/Views/Sidebar Title Views/SidebarTitleViewController.swift
@@ -21,7 +21,8 @@ import Cocoa
 
 class SidebarTitleViewController: NSViewController
 {
-	@IBOutlet unowned var leftSideButton: NSButton!
+	@IBOutlet unowned var firstLeftSideButton: NSButton!
+	@IBOutlet unowned var secondLeftSideButton: NSButton!
 	@IBOutlet unowned var titleLabel: NSTextField!
 	@IBOutlet unowned var subtitleLabel: NSTextField!
 
@@ -74,8 +75,12 @@ class SidebarTitleViewController: NSViewController
 		guard isViewLoaded else { return }
 
 		observations.removeAll()
-		leftSideButton.action = nil
-		leftSideButton.target = nil
+
+		for button in [firstLeftSideButton, secondLeftSideButton]
+		{
+			button?.action = nil
+			button?.target = nil
+		}
 	}
 
 	private func updateViews()
@@ -84,13 +89,13 @@ class SidebarTitleViewController: NSViewController
 
 		switch titleMode
 		{
-		case .none, .button(_, .none):
+		case .none, .buttons(_, .none):
 			titleLabel.stringValue = ""
 			titleLabel.isHidden = true
 			subtitleLabel.stringValue = ""
 			subtitleLabel.isHidden = true
 
-		case .subtitle(let title, let subtitle), .button(_, .subtitle(let title, let subtitle)):
+		case .subtitle(let title, let subtitle), .buttons(_, .subtitle(let title, let subtitle)):
 			let attrTitle = title.applyingAttributes(Self.titleAttributes)
 			let attrSubtitle = subtitle.applyingAttributes(Self.subtitleAttributes)
 
@@ -101,7 +106,7 @@ class SidebarTitleViewController: NSViewController
 			subtitleLabel.isHidden = false
 			subtitleLabel.installEmojiSubviews(using: attrSubtitle)
 
-		case .title(let title), .button(_, .title(let title)):
+		case .title(let title), .buttons(_, .title(let title)):
 			let attrTitle = title.applyingAttributes(Self.standaloneTitleAttributes)
 
 			titleLabel.attributedStringValue = attrTitle
@@ -111,50 +116,87 @@ class SidebarTitleViewController: NSViewController
 			subtitleLabel.isHidden = true
 			subtitleLabel.removeAllEmojiSubviews()
 
-		case .button(_, .button(_, _)):
+		case .buttons(_, .buttons(_, _)):
 			fatalError("You fucking bastard")
 		}
 
-		if case .button(let buttonStateBindable, _) = titleMode
+		if case .buttons(let buttonStateBindable, _) = titleMode
 		{
-			leftSideButton.isHidden = false
-			leftSideButton.action = #selector(SidebarTitleButtonStateBindable.didClickButton(_:))
-			leftSideButton.target = buttonStateBindable
-
-			observations.observe(buttonStateBindable, \.icon, sendInitial: true)
+			for button in [firstLeftSideButton, secondLeftSideButton]
 			{
-				[unowned self] (_, change) in
+				button?.isHidden = false
+				button?.target = buttonStateBindable
+			}
+
+			firstLeftSideButton.action = #selector(SidebarTitleButtonsStateBindable.didClickFirstButton(_:))
+			secondLeftSideButton.action = #selector(SidebarTitleButtonsStateBindable.didClickSecondButton(_:))
+
+			observations.observe(buttonStateBindable, \.firstIcon, sendInitial: true)
+			{
+				[unowned self] _, change in
 
 				if let image = change.newValue
 				{
-					self.leftSideButton.image = image
+					self.firstLeftSideButton.image = image
 				}
 			}
 
-			observations.observe(buttonStateBindable, \.accessibilityLabel, sendInitial: true)
+			observations.observe(buttonStateBindable, \.firstAccessibilityLabel, sendInitial: true)
 			{
-				[unowned self] (_, change) in
+				[unowned self] _, change in
 
 				if let label = change.newValue
 				{
-					self.leftSideButton.setAccessibilityLabel(label)
+					self.firstLeftSideButton.setAccessibilityLabel(label)
 				}
 			}
 
-			observations.observe(buttonStateBindable, \.accessibilityTitle, sendInitial: true)
+			observations.observe(buttonStateBindable, \.firstAccessibilityTitle, sendInitial: true)
 			{
-				[unowned self] (_, change) in
+				[unowned self] _, change in
 
 				if let title = change.newValue
 				{
-					self.leftSideButton.setAccessibilityTitle(title)
+					self.firstLeftSideButton.setAccessibilityTitle(title)
+				}
+			}
+
+			observations.observe(buttonStateBindable, \.secondIcon, sendInitial: true)
+			{
+				[unowned self] _, change in
+
+				if let image = change.newValue
+				{
+					self.secondLeftSideButton.image = image
+				}
+			}
+
+			observations.observe(buttonStateBindable, \.secondAccessibilityLabel, sendInitial: true)
+			{
+				[unowned self] _, change in
+
+				if let label = change.newValue
+				{
+					self.secondLeftSideButton.setAccessibilityLabel(label)
+				}
+			}
+
+			observations.observe(buttonStateBindable, \.secondAccessibilityTitle, sendInitial: true)
+			{
+				[unowned self] _, change in
+
+				if let title = change.newValue
+				{
+					self.secondLeftSideButton.setAccessibilityTitle(title)
 				}
 			}
 		}
 		else
 		{
-			leftSideButton.isHidden = true
+			for button in [firstLeftSideButton, secondLeftSideButton]
+			{
+				button?.isHidden = true
+			}
 		}
 	}
-
 }

--- a/Mastonaut/Views/Sidebar Title Views/SidebarTitleViewController.xib
+++ b/Mastonaut/Views/Sidebar Title Views/SidebarTitleViewController.xib
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="SidebarTitleViewController" customModule="Mastonaut" customModuleProvider="target">
             <connections>
-                <outlet property="leftSideButton" destination="iaa-JT-3Vi" id="hX3-9C-tf5"/>
+                <outlet property="firstLeftSideButton" destination="iaa-JT-3Vi" id="kK2-cR-xsY"/>
+                <outlet property="secondLeftSideButton" destination="c2Y-LV-99C" id="CAx-3w-Ots"/>
                 <outlet property="subtitleLabel" destination="OsD-tE-UAQ" id="xAr-7e-pr8"/>
                 <outlet property="titleLabel" destination="otD-Od-zUn" id="nlz-GY-4PX"/>
                 <outlet property="view" destination="26m-Xx-1gY" id="TiG-G5-CxZ"/>
@@ -16,21 +17,28 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="751" verticalHuggingPriority="751" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="752" misplaced="YES" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="26m-Xx-1gY">
+        <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="751" verticalHuggingPriority="751" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="752" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="26m-Xx-1gY">
             <rect key="frame" x="0.0" y="0.0" width="200" height="31"/>
             <subviews>
                 <button horizontalHuggingPriority="750" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="iaa-JT-3Vi">
-                    <rect key="frame" x="0.0" y="-1" width="22" height="32"/>
+                    <rect key="frame" x="-1" y="-2" width="24" height="34"/>
                     <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="bookmark" imagePosition="only" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Cgr-xS-oN4">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                 </button>
+                <button horizontalHuggingPriority="750" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="c2Y-LV-99C">
+                    <rect key="frame" x="29" y="-2" width="24" height="34"/>
+                    <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="bookmark" imagePosition="only" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="CsZ-Fx-BEq">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                </button>
                 <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="1" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="751" verticalHuggingPriority="751" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="751" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ufm-9b-cs4">
-                    <rect key="frame" x="30" y="0.0" width="170" height="31"/>
+                    <rect key="frame" x="60" y="0.0" width="140" height="31"/>
                     <subviews>
                         <textField horizontalHuggingPriority="752" verticalHuggingPriority="752" horizontalCompressionResistancePriority="500" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="otD-Od-zUn">
-                            <rect key="frame" x="9" y="15" width="153" height="16"/>
+                            <rect key="frame" x="-2" y="15" width="144" height="16"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="16" id="vhL-b9-0Sf"/>
                             </constraints>
@@ -41,7 +49,7 @@
                             </textFieldCell>
                         </textField>
                         <textField verticalHuggingPriority="751" horizontalCompressionResistancePriority="500" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="OsD-tE-UAQ">
-                            <rect key="frame" x="28" y="0.0" width="114" height="14"/>
+                            <rect key="frame" x="13" y="0.0" width="114" height="14"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="14" id="Bb4-QA-NJG"/>
                             </constraints>
@@ -66,8 +74,10 @@
             <visibilityPriorities>
                 <integer value="1000"/>
                 <integer value="1000"/>
+                <integer value="1000"/>
             </visibilityPriorities>
             <customSpacing>
+                <real value="3.4028234663852886e+38"/>
                 <real value="3.4028234663852886e+38"/>
                 <real value="3.4028234663852886e+38"/>
             </customSpacing>

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		5ECE4FACE2CB00D6ADAE8B11D11EA97D /* Card.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFDB7C679E18DE441820379A4215E442 /* Card.swift */; };
 		5F2F469A298EFFB300A1059B /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2F4698298EFF9700A1059B /* Response.swift */; };
 		5F2F469E298F012A00A1059B /* Result+isError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F2F469D298F012A00A1059B /* Result+isError.swift */; };
+		5F6F8F6D2A005EE600FB3414 /* Tags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6F8F6C2A005EE600FB3414 /* Tags.swift */; };
 		5F8C13432969FB1C007BE2D5 /* StatusEdit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8C13422969FB1C007BE2D5 /* StatusEdit.swift */; };
 		5FC21CF829C9E80000A582A8 /* SearchType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FC21CF729C9E80000A582A8 /* SearchType.swift */; };
 		5FD6B426293C003A008D90BE /* Bookmarks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD6B425293C003A008D90BE /* Bookmarks.swift */; };
@@ -611,6 +612,7 @@
 		5EAD4B42217DC5C178B6C210F6F23B56 /* ClientDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ClientDelegate.swift; path = Sources/MastodonKit/ClientDelegate.swift; sourceTree = "<group>"; };
 		5F2F4698298EFF9700A1059B /* Response.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Response.swift; path = Sources/MastodonKit/Response.swift; sourceTree = "<group>"; };
 		5F2F469D298F012A00A1059B /* Result+isError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Result+isError.swift"; path = "../Sources/MastodonKit/Extensions/Result+isError.swift"; sourceTree = "<group>"; };
+		5F6F8F6C2A005EE600FB3414 /* Tags.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Tags.swift; sourceTree = "<group>"; };
 		5F8C13422969FB1C007BE2D5 /* StatusEdit.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusEdit.swift; sourceTree = "<group>"; };
 		5FC21CF729C9E80000A582A8 /* SearchType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchType.swift; sourceTree = "<group>"; };
 		5FD6B425293C003A008D90BE /* Bookmarks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bookmarks.swift; sourceTree = "<group>"; };
@@ -1232,6 +1234,7 @@
 		32988D8CD764897FC881147EC0E934F6 /* Requests */ = {
 			isa = PBXGroup;
 			children = (
+				5F6F8F6C2A005EE600FB3414 /* Tags.swift */,
 				8757DBA1E59D400F082920F26D85E9CC /* Accounts.swift */,
 				199F52870B83987641F1CE5F4482BF91 /* Blocks.swift */,
 				530457C406B73917A591BF623595C327 /* Clients.swift */,
@@ -2367,6 +2370,7 @@
 				296B027F14A9D9212D6F71C0B6A7E3AE /* Media.swift in Sources */,
 				092A9CEB28D502BBEE90C4021EF5D92C /* MediaAttachment.swift in Sources */,
 				1D3B0DE1ACE9976DFD21FDA3323C0DB1 /* Mention.swift in Sources */,
+				5F6F8F6D2A005EE600FB3414 /* Tags.swift in Sources */,
 				21536C64A50E802B97F8EA254579523A /* Mutes.swift in Sources */,
 				5FC21CF829C9E80000A582A8 /* SearchType.swift in Sources */,
 				ACA69F689E937BDCFF8B49E128E53A84 /* Notification.swift in Sources */,


### PR DESCRIPTION
- [x] In a hashtag sidebar, have a state button to follow/unfollow a hashtag
- [x] API: model
- [x] API: fetch current hash tags for `hasFollowedTag`
- [x] API: `followTag` and `unfollowTag`
- [x] cleanup Core Data code; we probably won't be using it

(This is a tradeoff: we can store the followed tags locally, but then have to handle keeping them in sync, or we can simply ask the API each time.)