### PR TITLE
99-follow-requests: show notification filter preference

### DIFF
--- a/Mastonaut/Views/Preferences/NotificationTypeFilterPreferencesView.swift
+++ b/Mastonaut/Views/Preferences/NotificationTypeFilterPreferencesView.swift
@@ -51,7 +51,7 @@ struct NotificationTypeFilterPreferencesView: View {
 					.padding(.bottom, 10)
 
 				Toggle("New followers", isOn: $showNewFollowers)
-//				Toggle("Follow requests", isOn: $showFollowRequests)
+				Toggle("Follow requests", isOn: $showFollowRequests)
 					.padding(.bottom, 10)
 
 				Toggle("Boosts", isOn: $showBoosts)


### PR DESCRIPTION
For the person trying to follow:

- [ ] The profile page currently just keeps saying "follow". It probably doesn't know how to deal with this. Make it say "pending follow request"?

For the person receiving a request:

- [x] Show filter in preferences (this was hidden because its effect would have been confusing, since the actual notification wasn't implemented)
- [ ] show macOS notification
- [ ] hook up `MastodonNotification` type
- [ ] expand `FollowCellView`