### PR TITLE
Introduce a different URL scheme for login authorization when running the debug version

### DIFF
--- a/CoreTootin/Agents/AppRegistrationAgent.swift
+++ b/CoreTootin/Agents/AppRegistrationAgent.swift
@@ -60,9 +60,9 @@ public class AppRegistrationAgent
 		}
 	}
 
-	private func redirectUri(for baseDomain: String) -> String
-	{
-		return "mastonaut-auth://oauth/grant/\(baseDomain)/code/"
+	private func redirectUri(for baseDomain: String) -> String {
+		let urlScheme = Bundle.main.object(forInfoDictionaryKey: "MastonautAuthURLScheme") as? String ?? "mastonaut-auth"
+		return "\(urlScheme)://oauth/grant/\(baseDomain)/code/"
 	}
 
 	private func registerApplication(onInstance baseDomain: String,

--- a/Mastonaut.xcodeproj/project.pbxproj
+++ b/Mastonaut.xcodeproj/project.pbxproj
@@ -3719,6 +3719,7 @@
 			baseConfigurationReference = F78A836510592DFADE095479 /* Pods-Mastonaut.debug.xcconfig */;
 			buildSettings = {
 				APP_ICON_NAME = MastonautDebug;
+				AUTH_URL_SCHEME = "mastonaut-auth-debug";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Mastonaut/Supporting Files/Mastonaut.entitlements";
 				CODE_SIGN_IDENTITY = "-";
@@ -3752,6 +3753,7 @@
 			baseConfigurationReference = E884A5BDB042D4FBEE510962 /* Pods-Mastonaut.release.xcconfig */;
 			buildSettings = {
 				APP_ICON_NAME = Mastonaut;
+				AUTH_URL_SCHEME = "mastonaut-auth";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Mastonaut/Supporting Files/Mastonaut.entitlements";
 				CODE_SIGN_IDENTITY = "-";
@@ -3895,6 +3897,7 @@
 			baseConfigurationReference = D052D8D7DC75AE86FA6E38F0 /* Pods-Mastonaut.adhoc.xcconfig */;
 			buildSettings = {
 				APP_ICON_NAME = MastonautDebug;
+				AUTH_URL_SCHEME = "mastonaut-auth";
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = "Mastonaut/Supporting Files/Mastonaut.entitlements";
 				CODE_SIGN_IDENTITY = "-";

--- a/Mastonaut/Supporting Files/Info.plist
+++ b/Mastonaut/Supporting Files/Info.plist
@@ -31,7 +31,7 @@
 			<string>Mastonaut OAuth2 Callback</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>mastonaut-auth</string>
+				<string>$(AUTH_URL_SCHEME)</string>
 			</array>
 		</dict>
 	</array>
@@ -43,6 +43,8 @@
 	<string>public.app-category.social-networking</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>MastonautAuthURLScheme</key>
+	<string>$(AUTH_URL_SCHEME)</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>


### PR DESCRIPTION
I was having trouble logging in with the debug version running from Xcode, because the public version would be launched when the authorization completed in Safari, rather than the debug version getting the reply.

This change sets the debug version up with a different URL scheme so that this can't happen.